### PR TITLE
Feature/ua 787

### DIFF
--- a/src/app/analyzer/analyzer.component.spec.ts
+++ b/src/app/analyzer/analyzer.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, Input } from '@angular/core';
-import { AnalyzerService } from '../analyzer.service'; 
+import { AnalyzerService } from '../analyzer.service';
 import { DataPortalSettingsService } from '../data-portal-settings.service';
 import { AnalyzerComponent } from './analyzer.component';
 import { HelperService } from '../helper.service';


### PR DESCRIPTION
Improvement to analyzer chart:
**(Change from last PR)**: Example series: 150129 and 151881 (units: Thous) - These series will be drawn on separate axes in the analyzer. Adding another series with different units (i.e. 159107, units: $Mil) will move the first two series to the same axis and draw the new series on a new axis. 
**(New Change)**: Removing the series with $Mil units will now return to drawing the previous two series on separate axes.