### PR TITLE
remove hard coded default date ranges for uhero portal

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -83,7 +83,7 @@ import { ClipboardService } from './clipboard.service';
     },
     {
       provide: 'defaultRange',
-      useValue: { start: '2007', end: '2017', range: 10 }
+      useValue: { start: '', end: '', range: 10 }
     },
     {
       provide: 'portal',

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -73,15 +73,13 @@ export class DateSliderComponent implements OnChanges, AfterViewInit {
   findDefaultRange() {
     const defaultRanges = this._helper.setDefaultSliderRange(this.freq, this.dates, this.defaultRange);
     let startIndex = defaultRanges.start, endIndex = defaultRanges.end;
-    this.dates.forEach((date, index) => {
-      // Range slider is converting annual year strings to numbers
-      if (date == this.dateFrom) {
-        startIndex = index;
-      }
-      if (date == this.dateTo) {
-        endIndex = index;
-      }
-    });
+    // Range slider is converting annual year strings to numbers
+    const dateFromExists = this.dates.findIndex(date => date == this.dateFrom);
+    const dateToExists = this.dates.findIndex(date => date == this.dateTo);
+    if (dateFromExists > -1 && dateToExists > -1) {
+      startIndex = dateFromExists;
+      endIndex = dateToExists;
+    }
     return { start: startIndex, end: endIndex };
   }
 

--- a/src/app/helper.service.ts
+++ b/src/app/helper.service.ts
@@ -174,7 +174,7 @@ export class HelperService {
   }
 
   setDefaultChartRange(freq, dataArray, defaults) {
-    const defaultEnd = defaults.end;
+    const defaultEnd = defaults.end ? defaults.end : new Date(dataArray[dataArray.length - 1][0]).toISOString().substr(0, 4);
     let counter = dataArray.length - 1;
     while (new Date(dataArray[counter][0]).toISOString().substr(0, 4) > defaultEnd) {
       counter--;
@@ -183,7 +183,7 @@ export class HelperService {
   }
 
   setDefaultSliderRange(freq, dateArray, defaults) {
-    const defaultEnd = defaults.end;
+    const defaultEnd = defaults.end ? defaults.end : new Date(dateArray[dateArray.length - 1].toString().substr(0, 4)).toISOString().substr(0, 4);
     let counter = dateArray.length - 1;
     // https://github.com/IonDen/ion.rangeSlider/issues/298
     // Slider values being converted from strings to numbers for annual dates
@@ -194,7 +194,7 @@ export class HelperService {
   }
 
   setDefaultTableRange(freq, dateArray, defaults) {
-    const defaultEnd = defaults.end;
+    const defaultEnd = defaults.end ? defaults.end : new Date(dateArray[dateArray.length - 1].date).toISOString().substr(0, 4);
     let counter = dateArray.length - 1;
     while (new Date(dateArray[counter].date).toISOString().substr(0, 4) > defaultEnd) {
       counter--;

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -395,8 +395,9 @@ export class HighstockComponent implements OnChanges {
   }
 
   getSelectedChartRange(userStart, userEnd, levelData, defaults) {
+    const defaultEnd = defaults.end ? defaults.end : new Date(levelData[levelData.length - 1][0]).toISOString().substr(0, 4);    
     let counter = levelData.length ? levelData.length - 1 : null;
-    while (new Date(levelData[counter][0]).toISOString().substr(0, 4) > defaults.end) {
+    while (new Date(levelData[counter][0]).toISOString().substr(0, 4) > defaultEnd) {
       counter--;
     }
     const end = userEnd ? userEnd : new Date(levelData[counter][0]).toISOString().substr(0, 10);


### PR DESCRIPTION
Removed the values that forced the dates in the UHERO data portal to default to 2007-2017 on the category table/chart views for all frequencies. Instead, it should display up to the latest data available.

Testing:
In At A Glance, the annual dates should default to 2007 - 2017, but when switching to monthly, the default should be 2008-01 to 2018-01.