### PR TITLE
use unique tracking IDs for google analytics

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -28,6 +28,9 @@ describe('AppComponent', () => {
         AppComponent,
         HeaderStubComponent, SidebarNavStubComponent, FeedbackStubComponent
       ],
+      providers: [
+        { provide: 'GoogleAnalyticsId', useValue: 'gaId' }
+      ],
       imports: [ RouterTestingModule ]
     })
     .compileComponents()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
-declare var ga: Function;
+declare var gtag: Function;
 
 @Component({
   selector: 'app-root',
@@ -10,7 +10,8 @@ declare var ga: Function;
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  constructor(private titleService: Title, public _router: Router) {
+  constructor(@Inject('GoogleAnalyticsId') private gaId, private titleService: Title, public _router: Router) {
+    this.appendGATrackingCode(this.gaId);
     // Set title
     this.titleService.setTitle('Dataportal');
     // Set favicon
@@ -18,9 +19,7 @@ export class AppComponent implements OnInit {
 
     this._router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
-        // Send page views to Google Analytics
-        ga('set', 'page', event.urlAfterRedirects);
-        ga('send', 'pageview');
+        gtag('config', this.gaId, { 'page_path': event.urlAfterRedirects });
       }
     });
   }
@@ -33,6 +32,24 @@ export class AppComponent implements OnInit {
       }, 5000);
     } else {
       $('.browser').hide();
+    }
+  }
+
+  private appendGATrackingCode(gaId) {
+    try {
+      const gTagScript = document.createElement('script');
+      gTagScript.async = true;
+      gTagScript.src = "https://www.googletagmanager.com/gtag/js?id=" + gaId;
+      document.head.appendChild(gTagScript);
+      const script = document.createElement('script');
+      script.innerHTML = `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+      `;
+      document.head.appendChild(script);
+    } catch(err) {
+      console.log('Error adding Google Analytics', err);
     }
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,6 +88,10 @@ import { ClipboardService } from './clipboard.service';
     {
       provide: 'portal',
       useValue: 'uhero'
+    },
+    {
+      provide: 'GoogleAnalyticsId',
+      useValue: 'UA-18074519-3'
     }
   ],
   bootstrap: [AppComponent]

--- a/src/app/google-analytics-events.service.ts
+++ b/src/app/google-analytics-events.service.ts
@@ -1,15 +1,14 @@
 import { Injectable } from '@angular/core';
 
-declare var ga: Function;
+declare var gtag: Function;
 
 @Injectable()
 export class GoogleAnalyticsEventsService {
   constructor() { }
 
   public emitEvent(category: string, action: string, label: string) {
-    ga('send', 'event', {
+    gtag('event', action, {
       eventCategory: category,
-      eventAction: action,
       eventLabel: label
     });
   }

--- a/src/app/nta/app.component.spec.ts
+++ b/src/app/nta/app.component.spec.ts
@@ -28,6 +28,9 @@ describe('AppComponent', () => {
         AppComponent,
         HeaderStubComponent, SidebarNavStubComponent, FeedbackStubComponent
       ],
+      providers: [
+        { provide: 'GoogleAnalyticsId', useValue: 'gaId' }
+      ],
       imports: [ RouterTestingModule ]
     })
     .compileComponents()

--- a/src/app/nta/app.component.ts
+++ b/src/app/nta/app.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, OnChanges } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
-declare var ga: Function;
+declare var gtag: Function;
 
 @Component({
   selector: 'app-root',
@@ -10,13 +10,13 @@ declare var ga: Function;
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
-  constructor(private titleService: Title, public _router: Router) {
+  constructor(@Inject('GoogleAnalyticsId') private gaId, private titleService: Title, public _router: Router) {
+    this.appendGATrackingCode(this.gaId);
     this.titleService.setTitle('NTA Dataportal');
     this._router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         // Send page views to Google Analytics
-        ga('set', 'page', event.urlAfterRedirects);
-        ga('send', 'pageview');
+        gtag('config', this.gaId, { 'page_path': event.urlAfterRedirects });
       }
     });
   }
@@ -29,6 +29,24 @@ export class AppComponent implements OnInit {
       }, 5000);
     } else {
       $('.browser').hide();
+    }
+  }
+
+  private appendGATrackingCode(gaId) {
+    try {
+      const gTagScript = document.createElement('script');
+      gTagScript.async = true;
+      gTagScript.src = "https://www.googletagmanager.com/gtag/js?id=" + gaId;
+      document.head.appendChild(gTagScript);
+      const script = document.createElement('script');
+      script.innerHTML = `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+      `;
+      document.head.appendChild(script);
+    } catch(err) {
+      console.log('Error adding Google Analytics', err);
     }
   }
 }

--- a/src/app/nta/app.module.ts
+++ b/src/app/nta/app.module.ts
@@ -99,6 +99,10 @@ import { ClipboardService } from '../clipboard.service';
     {
       provide: 'portal',
       useValue: 'nta'
+    },
+    {
+      provide: 'GoogleAnalyticsId',
+      useValue: 'UA-18074519-4'
     }
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Allows each data portal to have a unique Google Analytics tracking ID. In Google, page views should be tracked in separate apps (UHERO Data Portal and NTA Data Portal).

*(The duplicate app.components will be consolidated into 1 file in feature/UA-875)