### PR TITLE
allow series package req to accept category id

### DIFF
--- a/src/app/category-charts/category-charts.component.html
+++ b/src/app/category-charts/category-charts.component.html
@@ -15,7 +15,7 @@
 	</ng-template>
 	<ng-template ngFor let-serie [ngForOf]="data" [ngForTrackBy]="trackBySeries">
 		<div *ngIf="!noSeries" class="multi-charts">
-			<a href="#" [routerLink]="['/series']" [queryParams]="{id: serie.seriesInfo.id, sa: serie.seriesInfo.saParam}" queryParamsHandling='merge'
+			<a href="#" [routerLink]="['/series']" [queryParams]="{id: serie.seriesInfo.id, sa: serie.seriesInfo.saParam, seriesCat: sublist.parentId}" queryParamsHandling='merge'
 			 *ngIf="serie.seriesInfo.id" (click)="submitGAEvent(serie.seriesInfo.id)">
 				<app-highchart [minValue]="sublist.minValue" [maxValue]="sublist.maxValue" [portalSettings]="portalSettings" [chartStart]="chartStart"
 				 [chartEnd]="chartEnd" [seriesData]="serie" [categoryDates]="dates" [currentFreq]="freq"></app-highchart>

--- a/src/app/category-table-renderer/category-table-renderer.component.html
+++ b/src/app/category-table-renderer/category-table-renderer.component.html
@@ -1,6 +1,6 @@
 <ng-template ngIf [ngIf]="params.data.lvlData">
   <span>
-    <a class="{{params.data.seriesInfo.indent ? 'indent' + params.data.seriesInfo.indent : ''}}" [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id, sa: params.data.seriesInfo.saParam }"
+    <a class="{{params.data.seriesInfo.indent ? 'indent' + params.data.seriesInfo.indent : ''}}" [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id, sa: params.data.seriesInfo.saParam, seriesCat: params.data.categoryId }"
       queryParamsHandling='merge'>{{params.value}}</a>
   </span>
   <div class="th-buttons">

--- a/src/app/category-table-view/category-table-view.component.ts
+++ b/src/app/category-table-view/category-table-view.component.ts
@@ -58,7 +58,7 @@ export class CategoryTableViewComponent implements OnInit, OnChanges {
         if (series.seriesInfo !== 'No data available' && this.dates) {
           const transformations = this._helper.getTransformations(series.seriesInfo.seriesObservations);
           const { level, yoy, ytd, c5ma } = transformations;
-          const seriesData = this.formatLvlData(series, level, this.subcatIndex);
+          const seriesData = this.formatLvlData(series, level, this.subcatIndex, this.sublist.parentId);
           this.rows.push(seriesData);
           if (this.yoyActive) {
             const yoyData = this.formatTransformationData(series, yoy);
@@ -109,14 +109,15 @@ export class CategoryTableViewComponent implements OnInit, OnChanges {
     return columns;
   }
 
-  formatLvlData = (series, level, subcatIndex) => {
+  formatLvlData = (series, level, subcatIndex, parentId) => {
     const { dates, values } = level;
     const seriesData = {
       series: series.seriesInfo.displayName,
       saParam: series.seriesInfo.saParam,
       seriesInfo: series.seriesInfo,
       lvlData: true,
-      subcatIndex: subcatIndex
+      subcatIndex: subcatIndex,
+      categoryId: parentId
     }
     dates.forEach((d, index) => {
       seriesData[d] = this._helper.formatNum(+values[index], series.seriesInfo.decimals);

--- a/src/app/series-helper.service.ts
+++ b/src/app/series-helper.service.ts
@@ -20,7 +20,7 @@ export class SeriesHelperService {
     private _helper: HelperService
   ) { }
 
-  getSeriesData(id: number): Observable<any> {
+  getSeriesData(id: number, catId?: number): Observable<any> {
     let currentFreq, currentGeo, decimals;
     this.seriesData = {
       seriesDetail: {},
@@ -37,7 +37,7 @@ export class SeriesHelperService {
     };
     const dateArray = [];
     const analyzerSeries = this._analyzer.analyzerSeries;
-    this._uheroAPIService.fetchPackageSeries(id).subscribe((data) => {
+    this._uheroAPIService.fetchPackageSeries(id, catId).subscribe((data) => {
       this.seriesData.seriesDetail = data.series;
       // Check if series is in the analyzer
       const existAnalyze = analyzerSeries.find(aSeries => aSeries.id === data.series.id);

--- a/src/app/share-link/share-link.component.ts
+++ b/src/app/share-link/share-link.component.ts
@@ -31,6 +31,7 @@ export class ShareLinkComponent implements OnInit, OnChanges {
   private id;
   private geo;
   private freq;
+  private seriesCat;
   private sa;
 
   private baseUrl;
@@ -54,6 +55,7 @@ export class ShareLinkComponent implements OnInit, OnChanges {
         this.geo = params['geo'] ? params['geo'] : null;
         this.freq = params['freq'] ? params['freq'] : null;
         this.sa = params['sa'] ? params['sa'] : null;
+        this.seriesCat = params['seriesCat'] ? params['seriesCat'] : null;
         this.shareLink = this.createSeriesShareLink();
       });
     }
@@ -117,6 +119,9 @@ export class ShareLinkComponent implements OnInit, OnChanges {
     }
     if (this.freq) {
       seriesUrl += '&freq=' + this.freq;
+    }
+    if (this.seriesCat)  {
+      seriesUrl += '&seriesCat=' + this.seriesCat;
     }
     if (start) {
       seriesUrl += '&start=' + start;

--- a/src/app/single-series/single-series.component.ts
+++ b/src/app/single-series/single-series.component.ts
@@ -83,11 +83,12 @@ export class SingleSeriesComponent implements OnInit, AfterViewInit {
   ngAfterViewInit() {
     this.route.queryParams.subscribe(params => {
       const seriesId = Number.parseInt(params['id']);
+      let categoryId;
       if (params['sa'] !== undefined) {
         this.seasonallyAdjusted = (params['sa'] === 'true');
       }
-      if (params['category']) {
-        this.category = params['category'];
+      if (params['seriesCat']) {
+        categoryId = Number.parseInt(params['seriesCat']);
       }
       if (params['start']) {
         this.startDate = params['start'];
@@ -95,7 +96,7 @@ export class SingleSeriesComponent implements OnInit, AfterViewInit {
       if (params['end']) {
         this.endDate = params['end'];
       }
-      this.seriesData = this._series.getSeriesData(seriesId);
+      this.seriesData = this._series.getSeriesData(seriesId, categoryId);
     });
     this.cdRef.detectChanges();
   }

--- a/src/app/uhero-api.service.ts
+++ b/src/app/uhero-api.service.ts
@@ -118,12 +118,11 @@ export class UheroApiService {
     }
   }
 
-  fetchPackageSeries(id: number) {
+  fetchPackageSeries(id: number, catId?: number) {
     if (this.cachedPackageSeries[id]) {
       return Observable.of(this.cachedPackageSeries[id]);
     } else {
-      let series$ = this.http.get(`${this.baseUrl}/package/series?id=` + id + `&u=` + this.portal.universe, this.requestOptionsArgs)
-        .map(mapData)
+      let series$ = this.http.get(`${this.baseUrl}/package/series?id=` + id + `&u=` + this.portal.universe + `&cat=` + catId, this.requestOptionsArgs).map(mapData)
         .do(val => {
           this.cachedPackageSeries[id] = val;
           series$ = null;


### PR DESCRIPTION
Navigating to a series from either the category level chart or table views sends a request to the API with the new cat parameter. It should show up in the data portal series URL as seriesCat.
(The only thing is that it doesn't work to limit regions on the COH portal when going to a series either from search results or the analyzer. I'm not sure how complicated it'd be to use the universe param to limit the regions, but just a head's up)

Testing locally:
Run the REST-API locally
`npm run start-coh-api-dev`
Click on any series in the chart or table view