### PR TITLE
Bugfix/ua 1020

### DIFF
--- a/src/app/HighstockObject.ts
+++ b/src/app/HighstockObject.ts
@@ -1,7 +1,7 @@
 export interface HighstockObject {
   chart: {
     alignTicks: boolean,
-    events: {
+    events?: {
       render: () => void,
     },
     zoomType: string,

--- a/src/app/analyzer-highstock/analyzer-highstock.component.spec.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.spec.ts
@@ -5,6 +5,7 @@ import { AnalyzerHighstockComponent } from './analyzer-highstock.component';
 import { AnalyzerService } from '../analyzer.service';
 import { UheroApiService } from '../uhero-api.service';
 import { HelperService } from '../helper.service';
+import { HighstockHelperService } from '../highstock-helper.service';
 
 // Create stub for chart component
 @Component({selector: 'highcharts-chart', template: ''})
@@ -28,6 +29,7 @@ describe('AnalyzerHighstockComponent', () => {
         AnalyzerService,
         UheroApiService,
         HelperService,
+        HighstockHelperService,
         { provide: 'rootCategory', useValue: 59 },
         {
           provide: 'portal',

--- a/src/app/analyzer-table/analyzer-table.component.html
+++ b/src/app/analyzer-table/analyzer-table.component.html
@@ -21,6 +21,7 @@
     [gridOptions]="statGridOptions" [frameworkComponents]="frameworkComponents">
   </ag-grid-angular>
 </ng-template>
+<p>Scroll to the right for additional statistics</p>
 <p *ngIf="missingSummaryStat" class="stat-warning">
   <i class="material-icons text-danger">&#xE001;</i> The following series contain N/As due to missing values included in the selected range:
   <ng-template ngFor let-serie [ngForOf]="summaryRows">

--- a/src/app/analyzer-table/analyzer-table.component.html
+++ b/src/app/analyzer-table/analyzer-table.component.html
@@ -17,11 +17,11 @@
     [frameworkComponents]="frameworkComponents" [gridOptions]="gridOptions" [enableRtl]="true" [suppressDragLeaveHidesColumns]="true"
     (gridReady)="onGridReady($event)">
   </ag-grid-angular>
+  <p class="stat-note">*Scroll to the right for additional statistics</p>
   <ag-grid-angular style="width: 100%;" class="ag-theme-balham" [rowData]="summaryRows" [columnDefs]="summaryColumns" domLayout="autoHeight"
     [gridOptions]="statGridOptions" [frameworkComponents]="frameworkComponents">
   </ag-grid-angular>
 </ng-template>
-<p>Scroll to the right for additional statistics</p>
 <p *ngIf="missingSummaryStat" class="stat-warning">
   <i class="material-icons text-danger">&#xE001;</i> The following series contain N/As due to missing values included in the selected range:
   <ng-template ngFor let-serie [ngForOf]="summaryRows">

--- a/src/app/analyzer-table/analyzer-table.component.scss
+++ b/src/app/analyzer-table/analyzer-table.component.scss
@@ -14,6 +14,12 @@
   font-size: 1.2em;
 }
 
+.stat-note {
+  font-size: 0.85em;
+  color: $primary-text;
+  margin-bottom: 0;
+}
+
 .transform-checks {
   display: inline-block;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { GoogleAnalyticsEventsService } from './google-analytics-events.service'
 import { HelpService } from './help.service';
 import { AnalyzerService } from './analyzer.service';
 import { TableHelperService } from './table-helper.service';
+import { HighstockHelperService } from './highstock-helper.service';
 import { UheroHelpComponent } from './uhero-help/uhero-help.component';
 import { ClipboardService } from './clipboard.service';
 import { RouterModule } from '@angular/router';
@@ -48,6 +49,7 @@ import { RouterModule } from '@angular/router';
     AnalyzerService,
     Title,
     ClipboardService,
+    HighstockHelperService,
     {
       provide: 'rootCategory',
       useValue: 59

--- a/src/app/hawaii-county/app.module.ts
+++ b/src/app/hawaii-county/app.module.ts
@@ -14,6 +14,7 @@ import { GoogleAnalyticsEventsService } from '../google-analytics-events.service
 import { HelpService } from '../help.service';
 import { AnalyzerService } from '../analyzer.service';
 import { TableHelperService } from '../table-helper.service';
+import { HighstockHelperService } from '../highstock-helper.service';
 import { AppComponent } from '../app.component';
 import { CohHelpComponent } from '../coh-help/coh-help.component';
 import { ClipboardService } from '../clipboard.service';
@@ -46,6 +47,7 @@ import { ClipboardService } from '../clipboard.service';
     AnalyzerService,
     Title,
     ClipboardService,
+    HighstockHelperService,
     {
       provide: 'rootCategory',
       useValue: 4429

--- a/src/app/highstock-helper.service.spec.ts
+++ b/src/app/highstock-helper.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { HighstockHelperService } from './highstock-helper.service';
+
+describe('HighstockHelperService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [HighstockHelperService]
+    });
+  });
+
+  it('should be created', inject([HighstockHelperService], (service: HighstockHelperService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+
+declare var require: any;
+const Highcharts = require('highcharts/js/highstock');
+
+@Injectable()
+export class HighstockHelperService {
+
+  constructor() { }
+
+  getChartExtremes = (chartObject) => {
+    // Gets range of x values to emit
+    // Used to redraw table in the single series view
+    let selectedRange = null;
+    if (!chartObject.series[0].points) {
+      return { min: null, max: null };
+    }
+    if (chartObject.series[0].points) {
+      selectedRange = chartObject.series[0].points;
+    }
+    if (selectedRange.length && chartObject._selectedMin && chartObject._selectedMax) {
+      return this.findVisibleMinMax(selectedRange, chartObject);
+    }
+  };
+
+  findVisibleMinMax = (selectedRange, chartObject) => {
+    let maxCounter = selectedRange.length - 1;
+    let minCounter = 0;
+    let xMin, xMax;
+    while (!xMax || xMax > chartObject._selectedMax) {
+      xMax = new Date(selectedRange[maxCounter].x).toISOString().split('T')[0];
+      maxCounter--;
+    }
+    while (!xMin || xMin < chartObject._selectedMin) {
+      xMin = new Date(selectedRange[minCounter].x).toISOString().split('T')[0];
+      minCounter++;
+    }
+    return { min: xMin, max: xMax };
+  };
+
+  getTooltipFreqLabel = (frequency, date) => {
+    if (frequency === 'A') {
+      return '';
+    }
+    if (frequency === 'Q') {
+      if (Highcharts.dateFormat('%b', date) === 'Jan') {
+        return 'Q1 ';
+      }
+      if (Highcharts.dateFormat('%b', date) === 'Apr') {
+        return 'Q2 ';
+      }
+      if (Highcharts.dateFormat('%b', date) === 'Jul') {
+        return 'Q3 ';
+      }
+      if (Highcharts.dateFormat('%b', date) === 'Oct') {
+        return 'Q4 ';
+      }
+    }
+    if (frequency === 'M' || frequency === 'S') {
+      return Highcharts.dateFormat('%b', date) + ' ';
+    }
+  };
+
+  xAxisLabelFormatter = (chart, freq) => {
+    let s = '';
+    const month = Highcharts.dateFormat('%b', chart.value);
+    const first = Highcharts.dateFormat('%Y', chart.axis.userMin);
+    const last = Highcharts.dateFormat('%Y', chart.axis.userMax);
+    s = ((last - first) <= 5) && freq === 'Q' ? s + this.getQuarterLabel(month) : '';
+    s = s + Highcharts.dateFormat('%Y', chart.value);
+    return freq === 'Q' ? s : chart.axis.defaultLabelFormatter.call(chart);
+  };
+
+  getQuarterLabel = (month) => {
+    if (month === 'Jan') {
+      return 'Q1 ';
+    }
+    if (month === 'Apr') {
+      return 'Q2 ';
+    }
+    if (month === 'Jul') {
+      return 'Q3 ';
+    }
+    if (month === 'Oct') {
+      return 'Q4 ';
+    }
+  };
+}

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -6,6 +6,7 @@ import { HighchartChartData } from '../highchart-chart-data';
 import { Series } from '../series';
 import { HighstockObject } from '../HighstockObject';
 import 'jquery';
+import { HighstockHelperService } from '../highstock-helper.service';
 declare var $: any;
 declare var require: any;
 const Highcharts = require('highcharts/js/highstock');
@@ -43,7 +44,10 @@ export class HighstockComponent implements OnChanges {
   chartObject;
   showChart = false;
 
-  constructor(@Inject('defaultRange') private defaultRange) { }
+  constructor(
+    @Inject('defaultRange') private defaultRange,
+    private _HighstockHelper: HighstockHelperService
+  ) {}
 
   ngOnChanges() {
     if (Object.keys(this.seriesDetail).length) {
@@ -179,8 +183,8 @@ export class HighstockComponent implements OnChanges {
     const tableExtremes = this.tableExtremes;
     const chartExtremes = this.chartExtremes;
     const formatTooltip = (points, x, pseudoZones, decimals, freq) => this.formatTooltip(points, x, pseudoZones, decimals, freq);
-    const getChartExtremes = (chartObject) => this.getChartExtremes(chartObject);
-
+    const getChartExtremes = (chartObject) => this._HighstockHelper.getChartExtremes(chartObject);
+    const xAxisFormatter = (chart, freq) => this._HighstockHelper.xAxisLabelFormatter(chart, freq);
     this.chartOptions.chart = {
       alignTicks: false,
       zoomType: 'x',
@@ -271,28 +275,7 @@ export class HighstockComponent implements OnChanges {
       ordinal: false,
       labels: {
         formatter: function () {
-          const getQLabel = function (month) {
-            if (month === 'Jan') {
-              return 'Q1 ';
-            }
-            if (month === 'Apr') {
-              return 'Q2 ';
-            }
-            if (month === 'Jul') {
-              return 'Q3 ';
-            }
-            if (month === 'Oct') {
-              return 'Q4 ';
-            }
-          };
-          let s = '';
-          const month = Highcharts.dateFormat('%b', this.value);
-          const frequency = this.chart.options.chart.description;
-          const first = Highcharts.dateFormat('%Y', this.axis.userMin);
-          const last = Highcharts.dateFormat('%Y', this.axis.userMax);
-          s = ((last - first) <= 5) && frequency === 'Q' ? s + getQLabel(month) : '';
-          s = s + Highcharts.dateFormat('%Y', this.value);
-          return frequency === 'Q' ? s : this.axis.defaultLabelFormatter.call(this);
+          return xAxisFormatter(this, this.chart.options.chart.description);
         }
       }
     };
@@ -332,59 +315,8 @@ export class HighstockComponent implements OnChanges {
     this.chartOptions.series = series;
   }
 
-  getChartExtremes = (chartObject) => {
-    // Gets range of x values to emit
-    // Used to redraw table in the single series view
-    let selectedRange = null;
-    if (!chartObject.series[0].points) {
-      return { min: null, max: null };
-    }
-    if (chartObject.series[0].points) {
-      selectedRange = chartObject.series[0].points;
-    }
-    if (selectedRange.length && chartObject._selectedMin && chartObject._selectedMax) {
-      return this.findVisibleMinMax(selectedRange, chartObject);
-    }
-  };
-
-  findVisibleMinMax = (selectedRange, chartObject) => {
-    let maxCounter = selectedRange.length - 1;
-    let minCounter = 0;
-    let xMin, xMax;
-    while (!xMax || xMax > chartObject._selectedMax) {
-      xMax = new Date(selectedRange[maxCounter].x).toISOString().split('T')[0];
-      maxCounter--;
-    }
-    while (!xMin || xMin < chartObject._selectedMin) {
-      xMin = new Date(selectedRange[minCounter].x).toISOString().split('T')[0];
-      minCounter++;
-    }
-    return { min: xMin, max: xMax };
-  }
-
   formatTooltip = (points, x, pseudoZones, decimals, freq) => {
-    const getFreqLabel = function (frequency, date) {
-      if (frequency === 'A') {
-        return '';
-      }
-      if (frequency === 'Q') {
-        if (Highcharts.dateFormat('%b', date) === 'Jan') {
-          return 'Q1 ';
-        }
-        if (Highcharts.dateFormat('%b', date) === 'Apr') {
-          return 'Q2 ';
-        }
-        if (Highcharts.dateFormat('%b', date) === 'Jul') {
-          return 'Q3 ';
-        }
-        if (Highcharts.dateFormat('%b', date) === 'Oct') {
-          return 'Q4 ';
-        }
-      }
-      if (frequency === 'M' || frequency === 'S') {
-        return Highcharts.dateFormat('%b', date);
-      }
-    };
+    const getFreqLabel = (frequency, date) => this._HighstockHelper.getTooltipFreqLabel(frequency, date);
     const pseudo = 'Pseudo History ';
     let s = '<b>';
     s = s + getFreqLabel(freq.freq, x);

--- a/src/app/nta/app.module.ts
+++ b/src/app/nta/app.module.ts
@@ -16,6 +16,7 @@ import { GoogleAnalyticsEventsService } from '../google-analytics-events.service
 import { TableHelperService } from '../table-helper.service';
 import { HelpService } from '../help.service';
 import { AnalyzerService } from '../analyzer.service';
+import { HighstockHelperService } from '../highstock-helper.service';
 import { AppComponent } from '../app.component';
 import { NtaHelpComponent } from '../nta-help/nta-help.component';
 import { NtaLayoutComponent } from './nta-layout/nta-layout.component';
@@ -55,6 +56,7 @@ import { ClipboardService } from '../clipboard.service';
     GoogleAnalyticsEventsService,
     HelpService,
     ClipboardService,
+    HighstockHelperService,
     Title,
     {
       provide: 'rootCategory',


### PR DESCRIPTION
Similar to the last PR. The analyzer table currently can show an extra observation (https://data.uhero.hawaii.edu/#/analyzer?analyzerSeries=150130&chartSeries=150130&start=2013-04-01&end=2018-04-01). Users can only see up to 2018 Q2 when hovering over the chart, but the table is displaying up to Q3. This update should fix that issue, and I also added a note above the summary statistics table to indicate that users can scroll through the table.
I created the highstock-helper.service to clean up some of the duplicated functions that were used in the analyzer-highstock and highstock components.