### PR TITLE
 Feature/ua 1026

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4743,9 +4743,9 @@
       "dev": true
     },
     "highcharts": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.1.1.tgz",
-      "integrity": "sha512-etFYUPb+CwG9mrTb08IS4k3XGXs94xSA9vNF1yTJLxL/rw6t9U0InrcMRKG7IVNc5MolMXOPAPCdkuzKXV3Gng=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.2.0.tgz",
+      "integrity": "sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ=="
     },
     "highcharts-angular": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ag-grid-community": "^19.0.0",
     "bootstrap": "^4.0.0-beta.2",
     "core-js": "^2.5.4",
-    "highcharts": "^6.1.1",
+    "highcharts": "^6.2.0",
     "highcharts-angular": "^2.3.1",
     "highcharts-export-csv": "^1.4.3",
     "ion-rangeslider": "^2.1.7",

--- a/src/app/HighstockObject.ts
+++ b/src/app/HighstockObject.ts
@@ -23,7 +23,9 @@ export interface HighstockObject {
     labelStyle: {
       visibility: string
     },
-    inputEnabled: boolean
+    inputEnabled: boolean,
+    inputDateFormat: string,
+    inputEditDateFormat: string,
   },
   lang: {
     exportKey: string

--- a/src/app/HighstockObject.ts
+++ b/src/app/HighstockObject.ts
@@ -16,7 +16,7 @@ export interface HighstockObject {
   rangeSelector: {
     selected: number,
     buttons: Array<any>,
-    buttonPosition: {
+    buttonPosition?: {
       x: number,
       y: number
     },
@@ -26,6 +26,7 @@ export interface HighstockObject {
     inputEnabled: boolean,
     inputDateFormat: string,
     inputEditDateFormat: string,
+    inputDateParser: (args: any) => any
   },
   lang: {
     exportKey: string
@@ -96,7 +97,7 @@ export interface HighstockObject {
     events: {
       afterSetExtremes: () => void
     },
-    minRange: number,
+    minRange?: number,
     min: number,
     max: number,
     ordinal: boolean,

--- a/src/app/HighstockObject.ts
+++ b/src/app/HighstockObject.ts
@@ -26,7 +26,11 @@ export interface HighstockObject {
     inputEnabled: boolean,
     inputDateFormat: string,
     inputEditDateFormat: string,
-    inputDateParser: (args: any) => any
+    inputDateParser: (args: any) => any,
+    inputPosition?: {
+      x: number,
+      y: number
+    }
   },
   lang: {
     exportKey: string

--- a/src/app/analyzer-highstock/analyzer-highstock.component.scss
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.scss
@@ -54,6 +54,11 @@
     }
 }
 
+input.highcharts-range-selector {
+    color: $primary-text;
+    font-size: 0.85em;
+}
+
 .highcharts-subtitle {
     fill: $primary-text;
     font-weight: bold;

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -15,6 +15,17 @@ exporting(Highcharts);
 offlineExport(Highcharts);
 exportCSV(Highcharts);
 
+Highcharts.setOptions({
+  navigator: {
+    xAxis: {
+        isInternal: true
+      },
+    yAxis: {
+        isInternal: true
+      }
+  }
+});
+
 @Component({
   selector: 'app-analyzer-highstock',
   templateUrl: './analyzer-highstock.component.html',
@@ -51,12 +62,27 @@ export class AnalyzerHighstockComponent implements OnChanges {
       selectedAnalyzerSeries = this.formatSeriesData(this.series, this.allDates, yAxes, this.navigator);
     }
     if (this.chartObject) {
-      console.log('onChanges', this.chartObject)
+      console.log('onChanges', this.chartObject);
+      console.log(selectedAnalyzerSeries)
       // If the chart has already been drawn, check to see if another y-axis needs to be added
       yAxes.forEach((y) => {
         const axisExists = this.chartObject.yAxis.findIndex(a => a.userOptions.id === y.id)
         if (axisExists === -1) {
           this.chartObject.addAxis(y);
+        }
+      });
+      this.chartObject.series.forEach((s) => {
+        console.log('s', s);
+        const displayInChart = selectedAnalyzerSeries.find(serie => serie.name === s.name && s.data.length === serie.data.length);
+        console.log('displayInChart', displayInChart)
+        if (!displayInChart) {
+          s.remove()
+        }
+      });
+      selectedAnalyzerSeries.forEach((s) => {
+        const inChart = this.chartObject.series.find(serie => serie.name === s.name && serie.data.length === s.data.length);
+        if (!inChart) {
+          this.chartObject.addSeries(s);
         }
       });
     }

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -15,17 +15,6 @@ exporting(Highcharts);
 offlineExport(Highcharts);
 exportCSV(Highcharts);
 
-/* Highcharts.setOptions({
-  navigator: {
-    xAxis: {
-        isInternal: true
-      },
-    yAxis: {
-        isInternal: true
-      }
-  }
-}); */
-
 @Component({
   selector: 'app-analyzer-highstock',
   templateUrl: './analyzer-highstock.component.html',
@@ -347,7 +336,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const xAxisFormatter = (chart, freq) => this._highstockHelper.xAxisLabelFormatter(chart, freq);
     const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
     const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);
-    const setInputDateParser = value => this._highstockHelper.inputDateParserFormatter(value);
+    const setInputDateParser = (value, freq) => this._highstockHelper.inputDateParserFormatter(value, freq);
     const tableExtremes = this.tableExtremes;
     this.chartOptions.chart = {
       alignTicks: false,
@@ -401,7 +390,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
       inputDateFormat: setInputDateFormat(navigatorOptions.frequency),
       inputEditDateFormat: setInputEditDateFormat(navigatorOptions.frequency),
       inputDateParser: function (value) {
-        return setInputDateParser(value);
+        return setInputDateParser(value, navigatorOptions.frequency);
       },
       inputPosition: {
         x: -30,

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -15,7 +15,7 @@ exporting(Highcharts);
 offlineExport(Highcharts);
 exportCSV(Highcharts);
 
-Highcharts.setOptions({
+/* Highcharts.setOptions({
   navigator: {
     xAxis: {
         isInternal: true
@@ -24,7 +24,7 @@ Highcharts.setOptions({
         isInternal: true
       }
   }
-});
+}); */
 
 @Component({
   selector: 'app-analyzer-highstock',

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -340,7 +340,9 @@ export class AnalyzerHighstockComponent implements OnChanges {
       labelStyle: {
         visibility: 'hidden'
       },
-      inputEnabled: false
+      inputEnabled: true,
+      inputDateFormat: navigatorOptions.frequency === 'A' ? '%Y' : '%b %e, %Y',
+      inputEditDateFormat: navigatorOptions.frequency === 'A' ? '%Y' : '%Y-%m-%d'
     };
     this.chartOptions.lang = {
       exportKey: 'Download Chart'

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -3,6 +3,7 @@ import { AnalyzerService } from '../analyzer.service';
 import { HighstockObject } from '../HighstockObject';
 import 'jquery';
 import { HighstockHelperService } from '../highstock-helper.service';
+import { HighchartsObject } from 'app/HighchartsObject';
 declare var $: any;
 declare var require: any;
 declare var require: any;
@@ -42,6 +43,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
   constructor(private _highstockHelper: HighstockHelperService) { }
 
   ngOnChanges() {
+    console.log('test')
     // Series in the analyzer that have been selected to be displayed in the chart
     let selectedAnalyzerSeries, yAxes;
     if (this.series.length) {
@@ -49,6 +51,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
       selectedAnalyzerSeries = this.formatSeriesData(this.series, this.allDates, yAxes, this.navigator);
     }
     if (this.chartObject) {
+      console.log('onChanges', this.chartObject)
       // If the chart has already been drawn, check to see if another y-axis needs to be added
       yAxes.forEach((y) => {
         const axisExists = this.chartObject.yAxis.findIndex(a => a.userOptions.id === y.id)
@@ -314,6 +317,20 @@ export class AnalyzerHighstockComponent implements OnChanges {
     this.chartOptions.chart = {
       alignTicks: false,
       description: undefined,
+      events: {
+        render: function () {
+          console.log('render');
+          const userMin = new Date(this.xAxis[0].getExtremes().min).toISOString().split('T')[0];
+          const userMax = new Date(this.xAxis[0].getExtremes().max).toISOString().split('T')[0];
+          this._selectedMin = navigatorOptions.frequency === 'A' ? userMin.substr(0, 4) + '-01-01' : userMin;
+          this._selectedMax = navigatorOptions.frequency === 'A' ? userMax.substr(0, 4) + '-01-01' : userMax;
+          this._hasSetExtremes = true;
+          this._extremes = getChartExtremes(this);
+          if (this._extremes) {
+            tableExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max });
+          }
+        }
+      },
       zoomType: 'x'
     };
     this.chartOptions.labels = {

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -307,6 +307,9 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const formatTooltip = (args, points, x, name, units, geo) => this.formatTooltip(args, points, x, name, units, geo);
     const getChartExtremes = (chartObject) => this._highstockHelper.getChartExtremes(chartObject);
     const xAxisFormatter = (chart, freq) => this._highstockHelper.xAxisLabelFormatter(chart, freq);
+    const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
+    const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);
+    const setInputDateParser = value => this._highstockHelper.inputDateParserFormatter(value);
     const tableExtremes = this.tableExtremes;
     this.chartOptions.chart = {
       alignTicks: false,
@@ -336,13 +339,15 @@ export class AnalyzerHighstockComponent implements OnChanges {
     this.chartOptions.rangeSelector = {
       selected: !startDate && !endDate ? 3 : null,
       buttons: buttons,
-      buttonPosition: { x: 10, y: 10 },
       labelStyle: {
         visibility: 'hidden'
       },
       inputEnabled: true,
-      inputDateFormat: navigatorOptions.frequency === 'A' ? '%Y' : '%b %e, %Y',
-      inputEditDateFormat: navigatorOptions.frequency === 'A' ? '%Y' : '%Y-%m-%d'
+      inputDateFormat: setInputDateFormat(navigatorOptions.frequency),
+      inputEditDateFormat: setInputEditDateFormat(navigatorOptions.frequency),
+      inputDateParser: function (value) {
+        return setInputDateParser(value);
+      }
     };
     this.chartOptions.lang = {
       exportKey: 'Download Chart'
@@ -527,7 +532,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
           tooltip += getQuarterObs(quarterSeries, date, pointQuarter);
         }
       }
-      const dateLabel = getFreqLabel(point.series.userOptions.frequency, point.x) + Highcharts.dateFormat('%Y', x);
+      const dateLabel = getFreqLabel(point.series.userOptions.frequency, point.x);
       tooltip += formatSeriesLabel(name, units, geo, point.series, point.y, dateLabel, point.x, s);
     });
     return tooltip;

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -136,7 +136,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
   };
 
   checkMaxValues = (unit, baseMin, baseMax) => {
-  const yAxesGroups = [{ axisId: 'yAxis0', units: unit.units, series: [] }];
+    const yAxesGroups = [{ axisId: 'yAxis0', units: unit.units, series: [] }];
     unit.series.forEach((serie) => {
       // Check if series need to be drawn on separate axes
       const level = serie.chartData ? serie.chartData.level : serie.data;
@@ -305,7 +305,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const tooltipUnits = this.unitsChecked;
     const tooltipGeo = this.geoChecked;
     const formatTooltip = (args, points, x, name, units, geo) => this.formatTooltip(args, points, x, name, units, geo);
-    const getChartExtremes = (chartObject) => this._highstockHelper.getChartExtremes(chartObject);
+    const getChartExtremes = (chartObject) => this._highstockHelper.getAnalyzerChartExtremes(chartObject);
     const xAxisFormatter = (chart, freq) => this._highstockHelper.xAxisLabelFormatter(chart, freq);
     const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
     const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -39,50 +39,83 @@ export class HighstockHelperService {
   };
 
   getTooltipFreqLabel = (frequency, date) => {
+    const year = Highcharts.dateFormat('%Y', date);
+    const month = Highcharts.dateFormat('%b', date);
     if (frequency === 'A') {
-      return '';
+      return year;
     }
     if (frequency === 'Q') {
-      if (Highcharts.dateFormat('%b', date) === 'Jan') {
-        return 'Q1 ';
-      }
-      if (Highcharts.dateFormat('%b', date) === 'Apr') {
-        return 'Q2 ';
-      }
-      if (Highcharts.dateFormat('%b', date) === 'Jul') {
-        return 'Q3 ';
-      }
-      if (Highcharts.dateFormat('%b', date) === 'Oct') {
-        return 'Q4 ';
-      }
+      return year + this.getQuarterLabel(month);
     }
     if (frequency === 'M' || frequency === 'S') {
-      return Highcharts.dateFormat('%b', date) + ' ';
+      return Highcharts.dateFormat('%b', date) + year;
     }
   };
 
   xAxisLabelFormatter = (chart, freq) => {
     let s = '';
     const month = Highcharts.dateFormat('%b', chart.value);
+    const year = Highcharts.dateFormat('%Y', chart.value);
     const first = Highcharts.dateFormat('%Y', chart.axis.userMin);
     const last = Highcharts.dateFormat('%Y', chart.axis.userMax);
-    s = ((last - first) <= 5) && freq === 'Q' ? s + this.getQuarterLabel(month) : '';
-    s = s + Highcharts.dateFormat('%Y', chart.value);
+    //s = ((last - first) <= 5) && freq === 'Q' ? s + this.getQuarterLabel(month) : '';
+    //s = s + Highcharts.dateFormat('%Y', chart.value);
+    s = ((last - first) <= 5) && freq === 'Q' ? year + this.getQuarterLabel(month) : year;
     return freq === 'Q' ? s : chart.axis.defaultLabelFormatter.call(chart);
   };
 
-  getQuarterLabel = (month) => {
+  getQuarterLabel = (month: string) => {
     if (month === 'Jan') {
-      return 'Q1 ';
+      return ' Q1';
     }
     if (month === 'Apr') {
-      return 'Q2 ';
+      return ' Q2';
     }
     if (month === 'Jul') {
-      return 'Q3 ';
+      return ' Q3';
     }
     if (month === 'Oct') {
-      return 'Q4 ';
+      return ' Q4';
     }
+  };
+
+  inputDateFormatter = (freq: string) => {
+    if (freq === 'A') {
+      return '%Y';
+    }
+    if (freq === 'Q') {
+      return '%Y %Q';
+    }
+    return '%b %Y';
+  };
+
+  inputEditDateFormatter = (freq: string) => {
+    if (freq === 'A') {
+      return '%Y';
+    }
+    if (freq === 'Q') {
+      return '%Y %Q';
+    }
+    return '%Y-%m';
+  };
+
+  inputDateParserFormatter = (value: string) => {
+    const year = value.substr(0, 4);
+    if (value.includes('Q1')) {
+      return Date.parse(year + '-01-01');
+    }
+    if (value.includes('Q2')) {
+      return Date.parse(year + '-04-01');
+    }
+    if (value.includes('Q3')) {
+      return Date.parse(year + '-07-01');
+    }
+    if (value.includes('Q4')) {
+      return Date.parse(year + '-10-01');
+    }
+    if (value.length === 4) { // i.e. year only
+      return Date.parse(value + '-01-01');
+    }
+    return Date.parse(value + '-01');
   };
 }

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -25,7 +25,9 @@ export class HighstockHelperService {
 
   getAnalyzerChartExtremes = (chartObject) => {
     let selectedRange = null;
+    console.log('getAnalyzerChartExtremes')
     if (chartObject) {
+      console.log('chartObject', chartObject)
       selectedRange = chartObject.series.find(s => s.name === 'Navigator').points;
     }
     if (selectedRange) {

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -25,13 +25,11 @@ export class HighstockHelperService {
 
   getAnalyzerChartExtremes = (chartObject) => {
     let selectedRange = null;
-    console.log('getAnalyzerChartExtremes')
     if (chartObject) {
-      console.log('chartObject', chartObject)
-      selectedRange = chartObject.series.find(s => s.name === 'Navigator').points;
+      selectedRange = chartObject.series.find(s => s.name === 'Navigator');
     }
     if (selectedRange) {
-      return this.findVisibleMinMax(selectedRange, chartObject);
+      return this.findVisibleMinMax(selectedRange.points, chartObject);
     }
   };
 

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -85,6 +85,7 @@ export class HighstockHelperService {
     if (month === 'Oct') {
       return ' Q4';
     }
+    return '';
   };
 
   inputDateFormatter = (freq: string) => {

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -3,6 +3,24 @@ import { Injectable } from '@angular/core';
 declare var require: any;
 const Highcharts = require('highcharts/js/highstock');
 
+Highcharts.dateFormats = {
+  Q: function (timestamp) {
+    const month = +new Date(timestamp).toISOString().split('T')[0].substr(5, 2);
+    if (1 <= month && month <= 3) {
+      return 'Q1';
+    }
+    if (4 <= month && month <= 6) {
+      return 'Q2';
+    }
+    if (7 <= month && month <= 9) {
+      return 'Q3';
+    }
+    if (10 <= month && month <= 12) {
+      return 'Q4';
+    }
+  }
+};
+
 @Injectable()
 export class HighstockHelperService {
 
@@ -58,7 +76,7 @@ export class HighstockHelperService {
       return year + this.getQuarterLabel(month);
     }
     if (frequency === 'M' || frequency === 'S') {
-      return Highcharts.dateFormat('%b', date) + year;
+      return `${Highcharts.dateFormat('%b', date)} ${year}`;
     }
   };
 
@@ -108,23 +126,31 @@ export class HighstockHelperService {
     return '%Y-%m';
   };
 
-  inputDateParserFormatter = (value: string) => {
+  inputDateParserFormatter = (value: string, freq: string) => {
     const year = value.substr(0, 4);
-    if (value.includes('Q1')) {
-      return Date.parse(year + '-01-01');
+    if (freq === 'Q') {
+      if (value.toUpperCase().includes('Q1')) {
+        return Date.parse(`${year}-01-01`);
+      }
+      if (value.toUpperCase().includes('Q2')) {
+        return Date.parse(`${year}-04-01`);
+      }
+      if (value.toUpperCase().includes('Q3')) {
+        return Date.parse(`${year}-07-01`);
+      }
+      if (value.toUpperCase().includes('Q4')) {
+        return Date.parse(`${year}-10-01`);
+      }
     }
-    if (value.includes('Q2')) {
-      return Date.parse(year + '-04-01');
+    if (freq === 'A') {
+      return Date.parse(`${year}-01-01`);
     }
-    if (value.includes('Q3')) {
-      return Date.parse(year + '-07-01');
+    if (freq === 'M' || freq === 'S') {
+      if (!value.includes('-')) { // i.e. monthly frequency where user removes '-'
+        const month = value.substr(4, 2);
+        return Date.parse(`${year}-${month}-01`)
+      }
+      return Date.parse(`${value}-01`);
     }
-    if (value.includes('Q4')) {
-      return Date.parse(year + '-10-01');
-    }
-    if (value.length === 4) { // i.e. year only
-      return Date.parse(value + '-01-01');
-    }
-    return Date.parse(value + '-01');
   };
 }

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -23,6 +23,16 @@ export class HighstockHelperService {
     }
   };
 
+  getAnalyzerChartExtremes = (chartObject) => {
+    let selectedRange = null;
+    if (chartObject) {
+      selectedRange = chartObject.series.find(s => s.name === 'Navigator').points;
+    }
+    if (selectedRange) {
+      return this.findVisibleMinMax(selectedRange, chartObject);
+    }
+  };
+
   findVisibleMinMax = (selectedRange, chartObject) => {
     let maxCounter = selectedRange.length - 1;
     let minCounter = 0;
@@ -58,8 +68,6 @@ export class HighstockHelperService {
     const year = Highcharts.dateFormat('%Y', chart.value);
     const first = Highcharts.dateFormat('%Y', chart.axis.userMin);
     const last = Highcharts.dateFormat('%Y', chart.axis.userMax);
-    //s = ((last - first) <= 5) && freq === 'Q' ? s + this.getQuarterLabel(month) : '';
-    //s = s + Highcharts.dateFormat('%Y', chart.value);
     s = ((last - first) <= 5) && freq === 'Q' ? year + this.getQuarterLabel(month) : year;
     return freq === 'Q' ? s : chart.axis.defaultLabelFormatter.call(chart);
   };

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -179,7 +179,7 @@ export class HighstockComponent implements OnChanges {
     const tableExtremes = this.tableExtremes;
     const chartExtremes = this.chartExtremes;
     const formatTooltip = (points, x, pseudoZones, decimals, freq) => this.formatTooltip(points, x, pseudoZones, decimals, freq);
-    const getChartExtremes = (chartObject) => this.getChartExtremes(chartObject);
+    const getChartExtremes = chartObject => this.getChartExtremes(chartObject);
 
     this.chartOptions.chart = {
       alignTicks: false,
@@ -199,7 +199,9 @@ export class HighstockComponent implements OnChanges {
       buttons: chartButtons,
       buttonPosition: { x: 0, y: 10 },
       labelStyle: { visibility: 'hidden' },
-      inputEnabled: false,
+      inputEnabled: true,
+      inputDateFormat: freq.freq === 'A' ? '%Y' : '%b %e, %Y',
+      inputEditDateFormat: freq.freq === 'A' ? '%Y' : '%Y-%m-%d'
     };
     this.chartOptions.lang = { exportKey: 'Download Chart' };
     this.chartOptions.exporting = {

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -19,17 +19,17 @@ exportCSV(Highcharts);
 
 Highcharts.dateFormats = {
   Q: function (timestamp) {
-    const month = new Date(timestamp).toISOString().split('T')[0].substr(5, 2);
-    if (month === '01') {
+    const month = +new Date(timestamp).toISOString().split('T')[0].substr(5, 2);
+    if (1 <= month && month <= 3) {
       return 'Q1';
     }
-    if (month === '04') {
+    if (4 <= month && month <= 6) {
       return 'Q2';
     }
-    if (month === '07') {
+    if (7 <= month && month <= 9) {
       return 'Q3';
     }
-    if (month === '10') {
+    if (10 <= month && month <= 12) {
       return 'Q4';
     }
   }

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -278,6 +278,7 @@ export class HighstockComponent implements OnChanges {
           this._hasSetExtremes = true;
           this._extremes = getChartExtremes(this);
           const lastDate = seriesDetail.seriesObservations.observationEnd;
+          console.log('this', this)
           if (this._extremes) {
             tableExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max });
             chartExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max, endOfSample: lastDate === this._extremes.max ? true : false })

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -17,24 +17,6 @@ exporting(Highcharts);
 offlineExport(Highcharts);
 exportCSV(Highcharts);
 
-Highcharts.dateFormats = {
-  Q: function (timestamp) {
-    const month = +new Date(timestamp).toISOString().split('T')[0].substr(5, 2);
-    if (1 <= month && month <= 3) {
-      return 'Q1';
-    }
-    if (4 <= month && month <= 6) {
-      return 'Q2';
-    }
-    if (7 <= month && month <= 9) {
-      return 'Q3';
-    }
-    if (10 <= month && month <= 12) {
-      return 'Q4';
-    }
-  }
-}
-
 @Component({
   selector: 'app-highstock',
   templateUrl: './highstock.component.html',
@@ -205,7 +187,7 @@ export class HighstockComponent implements OnChanges {
     const xAxisFormatter = (chart, freq) => this._highstockHelper.xAxisLabelFormatter(chart, freq);
     const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
     const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);
-    const setInputDateParser = value => this._highstockHelper.inputDateParserFormatter(value);
+    const setInputDateParser = (value, freq) => this._highstockHelper.inputDateParserFormatter(value, freq);
     this.chartOptions.chart = {
       alignTicks: false,
       zoomType: 'x',
@@ -231,7 +213,7 @@ export class HighstockComponent implements OnChanges {
       inputDateFormat: setInputDateFormat(freq.freq),
       inputEditDateFormat: setInputEditDateFormat(freq.freq),
       inputDateParser: function (value) {
-        return setInputDateParser(value);
+        return setInputDateParser(value, freq.freq);
       },
       inputPosition: {
         x: -30,

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -222,12 +222,20 @@ export class HighstockComponent implements OnChanges {
     this.chartOptions.rangeSelector = {
       selected: null,
       buttons: chartButtons,
+      buttonPosition: {
+        x: -30,
+        y: 0
+      },
       labelStyle: { visibility: 'hidden' },
       inputEnabled: true,
       inputDateFormat: setInputDateFormat(freq.freq),
       inputEditDateFormat: setInputEditDateFormat(freq.freq),
       inputDateParser: function (value) {
         return setInputDateParser(value);
+      },
+      inputPosition: {
+        x: -30,
+        y: 0
       }
     };
     this.chartOptions.lang = { exportKey: 'Download Chart' };

--- a/src/app/series-helper.service.ts
+++ b/src/app/series-helper.service.ts
@@ -168,7 +168,7 @@ export class SeriesHelperService {
     const endIndex = dates.indexOf(end);
     const datesInRange = dates.slice(startIndex, endIndex + 1);
     const valuesInRange = level.slice(startIndex, endIndex + 1);
-    if (valuesInRange.includes(null)) {
+    if (valuesInRange.includes(null) || !datesInRange.length || !valuesInRange.length) {
       formattedStats.missing = true;
       return formattedStats;
     }

--- a/src/app/single-series/single-series.component.html
+++ b/src/app/single-series/single-series.component.html
@@ -6,7 +6,7 @@
       class="geo-selector"></app-geo-selector>
     <app-freq-selector *ngIf="portal !== 'nta' && data.frequencies" [freqs]="data.frequencies" [(selectedFreq)]="data.currentFreq"
       (selectedFreqChange)="goToSeries(data.siblings, $event.freq, data.currentGeo.handle, seasonallyAdjusted)" class="freq-selector"></app-freq-selector>
-    <i *ngIf="data.seriesDetail" [title]="data.seriesDetail.analyze ? 'Remove from Analyzer' : 'Add to Analyzer'" [class.add-button]="!data.seriesDetail.analyze" [class.remove-button]="data.seriesDetail.analyze" class="material-icons analyze-button remove-button" (click)="updateAnalyze(data.seriesDetail, data.seriesTableData, data.chartData)">&#xE838;</i>
+    <i *ngIf="data.seriesDetail" [title]="data.seriesDetail.analyze ? 'Remove from Analyzer' : 'Add to Analyzer'" [class.add-button]="!data.seriesDetail.analyze" [class.remove-button]="data.seriesDetail.analyze" class="material-icons analyzer-toggle remove-button" (click)="updateAnalyze(data.seriesDetail, data.seriesTableData, data.chartData)">&#xE838;</i>
     <app-share-link [view]="'series'" [startDate]="chartStart" [endDate]="chartEnd"></app-share-link>
     <div class="form-check" *ngIf="data.saPairAvail">
       <label class="form-check-inline">

--- a/src/app/single-series/single-series.component.scss
+++ b/src/app/single-series/single-series.component.scss
@@ -34,7 +34,7 @@
     }
   }
 
-  .analyze-button {
+  .analyzer-toggle {
     color: rgba(240, 240, 240, 0.65);
     cursor: pointer;
     vertical-align: middle;

--- a/src/app/single-series/single-series.component.ts
+++ b/src/app/single-series/single-series.component.ts
@@ -130,7 +130,7 @@ export class SingleSeriesComponent implements OnInit, AfterViewInit {
 
   updateChartExtremes(e) {
     this.chartStart = e.minDate;
-    this.chartEnd = e.endOfSample ? null : e.maxDate.substr(0, 4);
+    this.chartEnd = e.endOfSample ? null : e.maxDate;
   }
 
   // Update table when selecting new ranges in the chart


### PR DESCRIPTION
Enables the range selector inputs on the Highstock charts, so users can enter dates at the top right of the chart (single series & analyzer) to more precisely define the date ranges rather than having to drag the navigator/slider at the bottom.
Formats accepted in the inputs:
Annual series: YYYY
Quarterly series: YYYY Q#
Monthly/Semiannual series: YYYY-MM