### PR TITLE
Bugfix/ua 1027

### DIFF
--- a/src/app/category-table-view/category-table-view.component.ts
+++ b/src/app/category-table-view/category-table-view.component.ts
@@ -51,6 +51,7 @@ export class CategoryTableViewComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges() {
+    console.log('tableStart', this.tableStart)
     this.columnDefs = this.setTableColumns(this.dates, this.freq, this.defaultRange, this.tableStart, this.tableEnd);
     this.rows = [];
     if (this.data) {
@@ -94,14 +95,20 @@ export class CategoryTableViewComponent implements OnInit, OnChanges {
     dates.forEach((date, index) => {
       // Range slider is converting annual year strings to numbers
       if (date.tableDate == tableStart) {
+        console.log('date.tableDate', date.tableDate);
+        console.log('tableStart', tableStart)
         startIndex = index;
       }
       if (date.tableDate == tableEnd) {
         endIndex = index;
       }
     });
-    const start = startIndex;
-    const end = endIndex;
+    let start = startIndex;
+    let end = endIndex;
+    if (startIndex > endIndex) {
+      start = defaultRanges.startIndex;
+      end = defaultRanges.endIndex;
+    }
     const tableDates = dates.slice(start, end + 1);
     // Reverse dates for right-to-left scrolling on tables
     for (let i = tableDates.length - 1; i >= 0; i--) {

--- a/src/app/date-slider/date-slider.component.html
+++ b/src/app/date-slider/date-slider.component.html
@@ -1,5 +1,5 @@
-<input type="text" [value]="sliderDates[start]" class="date-input js-from" />
+<input type="text" [id]="'dateFrom_' + subCat.id" [value]="sliderDates[start]" class="date-input js-from" />
 <div class="slider-container">
     <input *ngIf="subCat" class="sliders" type="text" [id]="'slider_' + subCat.id" value="" aria-label="date-range-slider" />
 </div>
-<input type="text" [value]="sliderDates[end]" class="date-input js-to" />
+<input type="text" [id]="'dateTo_' + subCat.id" [value]="sliderDates[end]" class="date-input js-to" />

--- a/src/app/date-slider/date-slider.component.html
+++ b/src/app/date-slider/date-slider.component.html
@@ -1,5 +1,5 @@
-<input *ngIf="subCat" class="sliders" type="text" [id]="'slider_' + subCat.id" value="" aria-label="date-range-slider"/>
-<div class="extra-controls">
-    <input type="text" [value]="sliderDates[start]" [pattern]="inputPattern" class="inp js-from" />
-    <input type="text" [value]="sliderDates[end]" [pattern]="inputPattern" class="inp js-to" />
+<input type="text" [value]="sliderDates[start]" class="date-input js-from" />
+<div class="slider-container">
+    <input *ngIf="subCat" class="sliders" type="text" [id]="'slider_' + subCat.id" value="" aria-label="date-range-slider" />
 </div>
+<input type="text" [value]="sliderDates[end]" class="date-input js-to" />

--- a/src/app/date-slider/date-slider.component.html
+++ b/src/app/date-slider/date-slider.component.html
@@ -1,5 +1,7 @@
-<input type="text" [id]="'dateFrom_' + subCat.id" [value]="sliderDates[start]" class="date-input js-from" />
+<label [for]="'dateFrom_' + subCat.id" class="visuallyhidden">Date From:</label>
+<input type="text" [name]="'dateFrom_' + subCat.id" [id]="'dateFrom_' + subCat.id" [value]="sliderDates[start]" class="date-input js-from" />
 <div class="slider-container">
     <input *ngIf="subCat" class="sliders" type="text" [id]="'slider_' + subCat.id" value="" aria-label="date-range-slider" />
 </div>
-<input type="text" [id]="'dateTo_' + subCat.id" [value]="sliderDates[end]" class="date-input js-to" />
+<label [for]="'dateTo_' + subCat.id" class="visuallyhidden">Date To:</label>
+<input type="text" [name]="'dateTo_' + subCat.id" [id]="'dateTo_' + subCat.id" [value]="sliderDates[end]" class="date-input js-to" />

--- a/src/app/date-slider/date-slider.component.html
+++ b/src/app/date-slider/date-slider.component.html
@@ -1,5 +1,5 @@
 <input *ngIf="subCat" class="sliders" type="text" [id]="'slider_' + subCat.id" value="" aria-label="date-range-slider"/>
 <div class="extra-controls">
-    <input type="text" maxlength="4" [value]="sliderDates[start]" class="inp js-from" />
-    <input type="text" maxlength="4" [value]="sliderDates[end]" class="inp js-to" />
+    <input type="text" [value]="sliderDates[start]" [pattern]="inputPattern" class="inp js-from" />
+    <input type="text" [value]="sliderDates[end]" [pattern]="inputPattern" class="inp js-to" />
 </div>

--- a/src/app/date-slider/date-slider.component.scss
+++ b/src/app/date-slider/date-slider.component.scss
@@ -8,6 +8,17 @@
     text-align: center;
 }
 
+.visuallyhidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
 .slider-container {
     display: inline-block;
     width: 150px;

--- a/src/app/date-slider/date-slider.component.scss
+++ b/src/app/date-slider/date-slider.component.scss
@@ -1,5 +1,25 @@
 @import 'app_colors';
 
+.js-to, .js-from {
+    display: inline-block;
+    width: 85px;
+    vertical-align: bottom;
+    font-size: 0.85em;
+    text-align: center;
+}
+
+.slider-container {
+    display: inline-block;
+    width: 150px;
+    margin: 0 20px;
+    vertical-align: bottom;
+
+    @media (max-width: 767px) {
+        width: 150px;
+        margin: 0 5px;
+    }
+}
+
 .irs-line-mid, .irs-line-left, .irs-line-right,
 .irs-bar, .irs-bar-edge, .irs-slider {
     background: url(../../sprite-skin-nice2.png) repeat-x;

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -40,10 +40,10 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    const $fromInput = $('.js-from');
-    const $toInput = $('.js-to');
+    const $fromInput = $(`#dateFrom_${this.subCat.id}`);
+    const $toInput = $(`#dateTo_${this.subCat.id}`);
     this.initRangeSlider(this.sliderDates, this.start, this.end, this.freq, this.portalSettings);
-    const $range = $('#slider_' + this.subCat.id).data('ionRangeSlider');
+    const $range = $(`#slider_${this.subCat.id}`).data('ionRangeSlider');
     // Set change functions for 'from' and 'to' date inputs
     this.setInputChangeFunction($fromInput, this.sliderDates, $range, 'from', this.portalSettings, this.freq);
     this.setInputChangeFunction($toInput, this.sliderDates, $range, 'to', this.portalSettings, this.freq);
@@ -51,26 +51,34 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
     this.cd.detectChanges();
   }
 
-  updateOtherSliders(sublist, subcatId, from, to) {
+  updateOtherSliders(sublist, subcatId, from, to, fromValue, toValue) {
     sublist.forEach((sub) => {
-      const slider = sub.id !== subcatId ? $('#slider_' + sub.id).data('ionRangeSlider') : null;
+      const slider = sub.id !== subcatId ? $(`#slider_${sub.id}`).data('ionRangeSlider') : null;
+      const $fromInput = sub.id !== subcatId ? $(`#dateFrom_${sub.id}`) : null;
+      const $toInput = sub.id !== subcatId ? $(`#dateTo_${sub.id}`) : null
       if (slider) {
         slider.update({
           from: from,
           to: to
         });
       }
+      if ($fromInput) {
+        $fromInput.prop('value', fromValue);
+      }
+      if ($toInput) {
+        $toInput.prop('value', toValue);
+      }
     });
   }
 
   initRangeSlider(sliderDates: Array<any>, start: number, end: number, freq: string, portalSettings) {
-    const updateOtherSliders = (sublist, subCatId, from, to) => this.updateOtherSliders(sublist, subCatId, from, to);
+    const updateOtherSliders = (sublist, subCatId, from, to, fromValue, toValue) => this.updateOtherSliders(sublist, subCatId, from, to, fromValue, toValue);
     const updateChartsAndTables = (from, to, freq) => this.updateChartsAndTables(from, to, freq);
     const sublist = this.sublist;
     const subCatId = this.subCat.id;
-    const $fromInput = $('.js-from');
-    const $toInput = $('.js-to');
-    $('#slider_' + this.subCat.id).ionRangeSlider({
+    const $fromInput = $(`#dateFrom_${subCatId}`);
+    const $toInput = $(`#dateTo_${subCatId}`);
+    $(`#slider_${subCatId}`).ionRangeSlider({
       min: 0,
       from: start,
       to: end,
@@ -82,7 +90,7 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
       type: 'double',
       onChange: function (data) {
         if (portalSettings.sliderInteraction) {
-          updateOtherSliders(sublist, subCatId, data.from, data.to);
+          updateOtherSliders(sublist, subCatId, data.from, data.to, data.from_value, data.to_value);
         }
         $fromInput.prop('value', data.from_value);
         $toInput.prop('value', data.to_value);
@@ -101,7 +109,8 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
 
   updateRanges(portalSettings, fromIndex: number, toIndex: number, from, to, freq: string) {
     if (portalSettings.sliderInteraction) {
-      this.updateOtherSliders(this.sublist, this.subCat.id, fromIndex, toIndex);
+      console.log('sliderInteraction')
+      this.updateOtherSliders(this.sublist, this.subCat.id, fromIndex, toIndex, from, to);
     }
     this.updateChartsAndTables(from, to, freq);
   }

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -1,9 +1,7 @@
 import { Component, Input, Inject, OnInit, ChangeDetectorRef, AfterViewInit, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
 import { HelperService } from '../helper.service';
 import 'jquery';
-import { validateConfig } from '@angular/router/src/config';
 declare var $: any;
-// import 'ion-rangeslider';
 
 @Component({
   selector: 'app-date-slider',
@@ -49,7 +47,6 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
     // Set change functions for 'from' and 'to' date inputs
     this.setInputChangeFunction($fromInput, this.sliderDates, $range, 'from', this.portalSettings, this.freq);
     this.setInputChangeFunction($toInput, this.sliderDates, $range, 'to', this.portalSettings, this.freq);
-    console.log('fromInput', $fromInput.prop('value'));
     this.updateChartsAndTables($fromInput.prop('value'), $toInput.prop('value'), this.freq)
     this.cd.detectChanges();
   }
@@ -97,11 +94,9 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   }
 
   updateChartsAndTables(from, to, freq: string) {
-    const chartStart = this.formatChartDate(from, freq);
-    const chartEnd = this.formatChartDate(to, freq);
-    const tableStart = from.toString();
-    const tableEnd = to.toString();
-    this.updateRange.emit({ chartStart: chartStart, chartEnd: chartEnd, tableStart: tableStart, tableEnd: tableEnd });
+    const seriesStart = this.formatChartDate(from, freq);
+    const seriesEnd = this.formatChartDate(to, freq);
+    this.updateRange.emit({ seriesStart: seriesStart, seriesEnd: seriesEnd });
   }
 
   updateRanges(portalSettings, fromIndex: number, toIndex: number, from, to, freq: string) {
@@ -181,8 +176,8 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   findDefaultRange = (dates: Array<any>, freq: string, defaultRange, dateFrom, dateTo) => {
     const sliderDates = dates.map(date => date.tableDate);
     if (dateFrom && dateTo) {
-      const dateFromExists = dates.findIndex(date => date.tableDate == dateFrom);
-      const dateToExists = dates.findIndex(date => date.tableDate == dateTo);
+      const dateFromExists = dates.findIndex(date => date.date == dateFrom);
+      const dateToExists = dates.findIndex(date => date.date == dateTo);
       if (dateFromExists > -1 && dateToExists > -1) {
         return { start: dateFromExists, end: dateToExists, sliderDates: sliderDates };
       }
@@ -196,17 +191,6 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
     const defaultRanges = this._helper.setDefaultSliderRange(freq, sliderDates, defaultRange);
     let { startIndex, endIndex } = defaultRanges;
     return { start: startIndex, end: endIndex, sliderDates: sliderDates };
-    /* const sliderDates = dates.map(date => date.tableDate);
-    const defaultRanges = this._helper.setDefaultSliderRange(freq, sliderDates, defaultRange);
-    let { startIndex, endIndex } = defaultRanges;
-    // Range slider is converting annual year strings to numbers
-    const dateFromExists = dates.findIndex(date => date.tableDate == dateFrom);
-    const dateToExists = dates.findIndex(date => date.tableDate == dateTo);
-    if (dateFromExists > -1 && dateToExists > -1) {
-      startIndex = dateFromExists;
-      endIndex = dateToExists;
-    }
-    return { start: startIndex, end: endIndex, sliderDates: sliderDates }; */
   }
 
   formatChartDate = (value, freq) => {

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -109,7 +109,6 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
 
   updateRanges(portalSettings, fromIndex: number, toIndex: number, from, to, freq: string) {
     if (portalSettings.sliderInteraction) {
-      console.log('sliderInteraction')
       this.updateOtherSliders(this.sublist, this.subCat.id, fromIndex, toIndex, from, to);
     }
     this.updateChartsAndTables(from, to, freq);
@@ -136,8 +135,8 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   }
 
   checkValidInputs = (value, siblingValue, key: string, freq: string) => {
-    const validInput = this.checkValidInputString(value.toUpperCase(), freq);
-    if (!validInput) {
+    const validString = this.checkValidInputString(value.toUpperCase(), freq);
+    if (!validString) {
       return false;
     }
     if (key === 'from') {

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -49,6 +49,8 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
     // Set change functions for 'from' and 'to' date inputs
     this.setInputChangeFunction($fromInput, this.sliderDates, $range, 'from', this.portalSettings, this.freq);
     this.setInputChangeFunction($toInput, this.sliderDates, $range, 'to', this.portalSettings, this.freq);
+    console.log('fromInput', $fromInput.prop('value'));
+    this.updateChartsAndTables($fromInput.prop('value'), $toInput.prop('value'), this.freq)
     this.cd.detectChanges();
   }
 
@@ -178,6 +180,23 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
 
   findDefaultRange = (dates: Array<any>, freq: string, defaultRange, dateFrom, dateTo) => {
     const sliderDates = dates.map(date => date.tableDate);
+    if (dateFrom && dateTo) {
+      const dateFromExists = dates.findIndex(date => date.tableDate == dateFrom);
+      const dateToExists = dates.findIndex(date => date.tableDate == dateTo);
+      if (dateFromExists > -1 && dateToExists > -1) {
+        return { start: dateFromExists, end: dateToExists, sliderDates: sliderDates };
+      }
+      if (dateFrom < dates[0].tableDate && dateToExists > -1) {
+        return { start: 0, end: dateToExists, sliderDates: sliderDates };
+      }
+      if (dateFromExists > -1 && dateTo > dates[dates.length - 1].tableDate) {
+        return { start: dateFromExists, end: dates.length - 1, sliderDates: sliderDates };
+      }
+    }
+    const defaultRanges = this._helper.setDefaultSliderRange(freq, sliderDates, defaultRange);
+    let { startIndex, endIndex } = defaultRanges;
+    return { start: startIndex, end: endIndex, sliderDates: sliderDates };
+    /* const sliderDates = dates.map(date => date.tableDate);
     const defaultRanges = this._helper.setDefaultSliderRange(freq, sliderDates, defaultRange);
     let { startIndex, endIndex } = defaultRanges;
     // Range slider is converting annual year strings to numbers
@@ -187,7 +206,7 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
       startIndex = dateFromExists;
       endIndex = dateToExists;
     }
-    return { start: startIndex, end: endIndex, sliderDates: sliderDates };
+    return { start: startIndex, end: endIndex, sliderDates: sliderDates }; */
   }
 
   formatChartDate = (value, freq) => {

--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -18,9 +18,9 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   @Input() dateTo;
   @Input() sublist;
   @Output() updateRange = new EventEmitter(true);
-  private start;
-  private end;
-  private sliderDates;
+  start;
+  end;
+  sliderDates;
 
   constructor(
     @Inject('defaultRange') private defaultRange,

--- a/src/app/highchart/highchart.component.ts
+++ b/src/app/highchart/highchart.component.ts
@@ -47,6 +47,34 @@ export class HighchartComponent implements OnChanges {
   }
 
   getSeriesStartAndEnd = (dates, start, end) => {
+    /* console.log('dates', dates);
+    console.log('start', start);
+    let startIndex, endIndex;
+    if (start && end) {
+      const startExists = dates.findIndex(date => date.date == start);
+      console.log('startExists', startExists)
+      const endExists = dates.findIndex(date => date.date == end);
+      if (startExists > -1 && endExists > -1) {
+        startIndex = startExists;
+        endIndex = endExists;
+      }
+      if (start < dates[0].date && endExists > -1) {
+        console.log('true')
+        startIndex = 0;
+        endIndex = endExists;
+      }
+      if (startExists > -1 && end > dates[dates.length - 1].date) {
+        startIndex = startExists;
+        endIndex = dates.length - 1;
+      }
+      return { seriesStart: startIndex, seriesEnd: endIndex };
+    }
+    const defaultRanges = this._helper.setDefaultCategoryRange(this.currentFreq, dates, this.defaultRange);
+    startIndex = defaultRanges.startIndex;
+    endIndex = defaultRanges.endIndex;
+    console.log('default')
+    return { seriesStart: startIndex, seriesEnd: endIndex }; */
+
     const defaultRanges = this._helper.setDefaultCategoryRange(this.currentFreq, dates, this.defaultRange);
     let { startIndex, endIndex } = defaultRanges;
     dates.forEach((item, index) => {
@@ -109,6 +137,7 @@ export class HighchartComponent implements OnChanges {
   };
 
   setChartSeries = (portalSettings, series0, currentFreq, startDate, pseudoZones, series1) => {
+    console.log('startDate', new Date(startDate).toISOString())
     const chartSeries = [];
     chartSeries.push({
       name: portalSettings.highcharts.series0Name,
@@ -152,6 +181,7 @@ export class HighchartComponent implements OnChanges {
     const { start, end } = seriesData.categoryDisplay;
     const { percent, title, unitsLabelShort, displayName } = seriesData.seriesInfo;
     const { seriesStart, seriesEnd } = this.getSeriesStartAndEnd(this.categoryDates, chartStart, chartEnd);
+    console.log('seriesStart', seriesStart);
     const decimals = seriesData.seriesInfo.decimals ? seriesData.seriesInfo.decimals : 1;
     let series0 = seriesData.categoryDisplay.chartData.series0;
     let series1 = seriesData.categoryDisplay.chartData.series1;

--- a/src/app/highchart/highchart.component.ts
+++ b/src/app/highchart/highchart.component.ts
@@ -47,34 +47,6 @@ export class HighchartComponent implements OnChanges {
   }
 
   getSeriesStartAndEnd = (dates, start, end) => {
-    /* console.log('dates', dates);
-    console.log('start', start);
-    let startIndex, endIndex;
-    if (start && end) {
-      const startExists = dates.findIndex(date => date.date == start);
-      console.log('startExists', startExists)
-      const endExists = dates.findIndex(date => date.date == end);
-      if (startExists > -1 && endExists > -1) {
-        startIndex = startExists;
-        endIndex = endExists;
-      }
-      if (start < dates[0].date && endExists > -1) {
-        console.log('true')
-        startIndex = 0;
-        endIndex = endExists;
-      }
-      if (startExists > -1 && end > dates[dates.length - 1].date) {
-        startIndex = startExists;
-        endIndex = dates.length - 1;
-      }
-      return { seriesStart: startIndex, seriesEnd: endIndex };
-    }
-    const defaultRanges = this._helper.setDefaultCategoryRange(this.currentFreq, dates, this.defaultRange);
-    startIndex = defaultRanges.startIndex;
-    endIndex = defaultRanges.endIndex;
-    console.log('default')
-    return { seriesStart: startIndex, seriesEnd: endIndex }; */
-
     const defaultRanges = this._helper.setDefaultCategoryRange(this.currentFreq, dates, this.defaultRange);
     let { startIndex, endIndex } = defaultRanges;
     dates.forEach((item, index) => {
@@ -137,7 +109,6 @@ export class HighchartComponent implements OnChanges {
   };
 
   setChartSeries = (portalSettings, series0, currentFreq, startDate, pseudoZones, series1) => {
-    console.log('startDate', new Date(startDate).toISOString())
     const chartSeries = [];
     chartSeries.push({
       name: portalSettings.highcharts.series0Name,
@@ -177,11 +148,9 @@ export class HighchartComponent implements OnChanges {
 
   drawChart = (seriesData, currentFreq: string, portalSettings, min: number, max: number, chartStart?, chartEnd?) => {
     const { dates, pseudoZones } = seriesData.categoryDisplay.chartData;
-    const { series0Name, series1Name } = portalSettings.highcharts;
     const { start, end } = seriesData.categoryDisplay;
     const { percent, title, unitsLabelShort, displayName } = seriesData.seriesInfo;
     const { seriesStart, seriesEnd } = this.getSeriesStartAndEnd(this.categoryDates, chartStart, chartEnd);
-    console.log('seriesStart', seriesStart);
     const decimals = seriesData.seriesInfo.decimals ? seriesData.seriesInfo.decimals : 1;
     let series0 = seriesData.categoryDisplay.chartData.series0;
     let series1 = seriesData.categoryDisplay.chartData.series1;

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -278,7 +278,6 @@ export class HighstockComponent implements OnChanges {
           this._hasSetExtremes = true;
           this._extremes = getChartExtremes(this);
           const lastDate = seriesDetail.seriesObservations.observationEnd;
-          console.log('this', this)
           if (this._extremes) {
             tableExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max });
             chartExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max, endOfSample: lastDate === this._extremes.max ? true : false })

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -45,7 +45,7 @@
 				 [tableStart]="tableStart" [tableEnd]="tableEnd" [sublist]="sub" [data]="sub.displaySeries" [geo]="data.currentGeo" [tableId]="sub.id"
 				 [freq]="data.currentFreq?.freq" [subcatIndex]="sub.id" [yoyActive]="queryParams.yoy === 'true'" [ytdActive]="queryParams.ytd === 'true'"
 				 [noSeries]="sub.noData" [params]="queryParams"></app-category-table-view>
-				<app-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings" [chartStart]="chartStart" [chartEnd]="chartEnd"
+				<app-category-charts *ngIf="routeView !== 'table' && displayCharts" [portalSettings]="portalSettings" [chartStart]="chartStart" [chartEnd]="chartEnd"
 				 [sublist]="sub" [data]="sub.displaySeries" [dateWrapper]="data.categoryDateWrapper" [dates]="data.categoryDates" [freq]="data.currentFreq?.freq"
 				 [noSeries]="sub.noData" [params]="queryParams"></app-category-charts>
 			</ng-template>

--- a/src/app/landing-page/landing-page.component.html
+++ b/src/app/landing-page/landing-page.component.html
@@ -37,15 +37,15 @@
 						<input type="checkbox" [checked]="queryParams.ytd === 'true'" (change)="ytdActive($event, sub.id)">Year-to-Date
 					</label>
 					<app-date-slider *ngIf="!sub.noData" class="sliders" [portalSettings]="portalSettings" [dates]="data.categoryDates" [sublist]="data.subcategories"
-					 [subCat]="sub" [dateFrom]="tableStart ? tableStart : null" [dateTo]="tableEnd ? tableEnd: null" [freq]="data.currentFreq?.freq"
+					 [subCat]="sub" [dateFrom]="seriesStart ? seriesStart : null" [dateTo]="seriesEnd ? seriesEnd: null" [freq]="data.currentFreq?.freq"
 					 (updateRange)="changeRange($event)"></app-date-slider>
 				</div>
-				<i *ngIf="!sub.requestComplete" class="fas fa-spinner fa-pulse fa-fw"></i>
+				<i *ngIf="!sub.requestComplete || !displaySeries" class="fas fa-spinner fa-pulse fa-fw"></i>
 				<app-category-table-view *ngIf="routeView === 'table' && sub.requestComplete" [portalSettings]="portalSettings" [dates]="data.categoryDates"
-				 [tableStart]="tableStart" [tableEnd]="tableEnd" [sublist]="sub" [data]="sub.displaySeries" [geo]="data.currentGeo" [tableId]="sub.id"
+				 [tableStart]="seriesStart" [tableEnd]="seriesEnd" [sublist]="sub" [data]="sub.displaySeries" [geo]="data.currentGeo" [tableId]="sub.id"
 				 [freq]="data.currentFreq?.freq" [subcatIndex]="sub.id" [yoyActive]="queryParams.yoy === 'true'" [ytdActive]="queryParams.ytd === 'true'"
 				 [noSeries]="sub.noData" [params]="queryParams"></app-category-table-view>
-				<app-category-charts *ngIf="routeView !== 'table' && displayCharts" [portalSettings]="portalSettings" [chartStart]="chartStart" [chartEnd]="chartEnd"
+				<app-category-charts *ngIf="routeView !== 'table' && displaySeries" [portalSettings]="portalSettings" [chartStart]="seriesStart" [chartEnd]="seriesEnd"
 				 [sublist]="sub" [data]="sub.displaySeries" [dateWrapper]="data.categoryDateWrapper" [dates]="data.categoryDates" [freq]="data.currentFreq?.freq"
 				 [noSeries]="sub.noData" [params]="queryParams"></app-category-charts>
 			</ng-template>

--- a/src/app/landing-page/landing-page.component.scss
+++ b/src/app/landing-page/landing-page.component.scss
@@ -18,10 +18,16 @@
 
     .sliders {
       display: inline-block;
-      width: 200px;
+      width: 400px;
       vertical-align: bottom;
       margin-left: 10px;
       margin-right: 10px;
+
+      @media (max-width: 767px) {
+        display: block;
+        width: 100%;
+        margin: 0;
+      }
     }
   }
 

--- a/src/app/landing-page/landing-page.component.scss
+++ b/src/app/landing-page/landing-page.component.scss
@@ -18,7 +18,7 @@
 
     .sliders {
       display: inline-block;
-      width: 400px;
+      width: 360px;
       vertical-align: bottom;
       margin-left: 10px;
       margin-right: 10px;

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -31,10 +31,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   private queryParams: any = {};
   private tableStart;
   private tableEnd;
-  private chartStart = null;
-  private chartEnd = null;
+  private seriesStart = null;
+  private seriesEnd = null;
   private portalSettings;
-  private displayCharts;
+  private displaySeries;
 
   // Variables for geo and freq selectors
   public currentGeo: Geography;
@@ -57,14 +57,12 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   ) {}
 
   ngOnInit() {
-    this.chartStart = null
     this.currentGeo = { fips: null, name: null, shortName: null, handle: null };
     this.currentFreq = { freq: null, label: null };
     this.portalSettings = this._dataPortalSettings.dataPortalSettings[this.portal.universe];
   }
 
   ngAfterViewInit() {
-    this.chartStart = null
     this.sub = this.route.queryParams.subscribe((params) => {
       this.id = this.getIdParam(params['id']);
       this.search = typeof this.id === 'string' ? true : false;
@@ -136,7 +134,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
 
   // Redraw series when a new region is selected
   redrawSeriesGeo(event, currentFreq, subId) {
-    this.displayCharts = false;
+    this.displaySeries = false;
     this.loading = true;
     setTimeout(() => {
       this.queryParams.geo = event.handle;
@@ -147,6 +145,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   redrawSeriesFreq(event, currentGeo, subId) {
+    this.displaySeries = false;
     this.loading = true;
     setTimeout(() => {
       this.queryParams.geo = currentGeo.handle;
@@ -184,12 +183,9 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   changeRange(e) {
-    console.log('changeRange', e)
-    this.tableStart = e.tableStart;
-    this.tableEnd = e.tableEnd;
-    this.chartStart = e.chartStart;
-    this.chartEnd = e.chartEnd;
-    this.displayCharts = true;
+    this.seriesStart = e.seriesStart;
+    this.seriesEnd = e.seriesEnd;
+    this.displaySeries = true;
   }
 
   // Work around for srolling to page anchor

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -31,9 +31,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   private queryParams: any = {};
   private tableStart;
   private tableEnd;
-  private chartStart;
-  private chartEnd;
+  private chartStart = null;
+  private chartEnd = null;
   private portalSettings;
+  private displayCharts;
 
   // Variables for geo and freq selectors
   public currentGeo: Geography;
@@ -56,12 +57,14 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   ) {}
 
   ngOnInit() {
+    this.chartStart = null
     this.currentGeo = { fips: null, name: null, shortName: null, handle: null };
     this.currentFreq = { freq: null, label: null };
     this.portalSettings = this._dataPortalSettings.dataPortalSettings[this.portal.universe];
   }
 
   ngAfterViewInit() {
+    this.chartStart = null
     this.sub = this.route.queryParams.subscribe((params) => {
       this.id = this.getIdParam(params['id']);
       this.search = typeof this.id === 'string' ? true : false;
@@ -133,12 +136,13 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
 
   // Redraw series when a new region is selected
   redrawSeriesGeo(event, currentFreq, subId) {
+    this.displayCharts = false;
     this.loading = true;
     setTimeout(() => {
       this.queryParams.geo = event.handle;
       this.queryParams.freq = currentFreq.freq;
       this.updateRoute(subId);
-    }, 10);
+    }, 20);
     this.scrollToFragment();
   }
 
@@ -180,10 +184,12 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   changeRange(e) {
+    console.log('changeRange', e)
     this.tableStart = e.tableStart;
     this.tableEnd = e.tableEnd;
     this.chartStart = e.chartStart;
     this.chartEnd = e.chartEnd;
+    this.displayCharts = true;
   }
 
   // Work around for srolling to page anchor

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -157,6 +157,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
 
   switchView(subId) {
     this.loading = true;
+    this.displaySeries = false;
     setTimeout(() => {
       this.queryParams.view = this.routeView === 'table' ? 'chart' : 'table';
       this.updateRoute(subId);
@@ -201,6 +202,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, AfterViewChe
     const urlPath = typeof this.queryParams.id === 'string' ? '/search' : '/category';
     this._router.navigate([urlPath], { queryParams: this.queryParams, queryParamsHandling: 'merge', fragment: this.fragment });
     this.loading = false;
+    this.displaySeries = true;
   }
 
   scrollTo(): void {

--- a/src/app/nta/nta-layout/nta-layout.component.html
+++ b/src/app/nta/nta-layout/nta-layout.component.html
@@ -31,16 +31,16 @@
 					<input type="checkbox" [checked]="queryParams.c5ma === 'true'" (change)="c5maActive($event, sub.id)">Annual Change
 				</label>
 				<app-date-slider class="sliders" *ngIf="sub.requestComplete" [portalSettings]="portalSettings" [dates]="sub.dateArray"
-				 [sublist]="data.sublist" [subCat]="sub" [dateFrom]="sub.tableStart ? sub.tableStart : null" [dateTo]="sub.tableEnd ? sub.tableEnd: null"
+				 [sublist]="data.sublist" [subCat]="sub" [dateFrom]="sub.seriesStart ? sub.seriesStart : null" [dateTo]="sub.seriesEnd ? sub.seriesEnd: null"
 				 [freq]="data.currentFreq?.freq" (updateRange)="changeRange($event, sub)"></app-date-slider>
-				<i *ngIf="!sub.requestComplete || loading" class="fas fa-spinner fa-pulse fa-fw"></i>
+				<i *ngIf="!displaySeries || loading" class="fas fa-spinner fa-pulse fa-fw"></i>
 			</div>
-			<app-category-table-view *ngIf="routeView === 'table' && sub.requestComplete" [portalSettings]="portalSettings" [dates]="sub.dateArray"
-			 [tableStart]="sub.tableStart" [tableEnd]="sub.tableEnd" [sublist]="sub" [data]="sub.scrollSeries[sub.scrollIndex]" [geo]="data.currentGeo" [tableId]="sub.id"
+			<app-category-table-view *ngIf="routeView === 'table' && displaySeries" [portalSettings]="portalSettings" [dates]="sub.dateArray"
+			 [tableStart]="sub.seriesStart" [tableEnd]="sub.seriesEnd" [sublist]="sub" [data]="sub.scrollSeries[sub.scrollIndex]" [geo]="data.currentGeo" [tableId]="sub.id"
 			 [freq]="data.currentFreq?.freq" [subcatIndex]="sub.id" [c5maActive]="queryParams.c5ma === 'true'"
 			 [noSeries]="sub.noData" [params]="queryParams"></app-category-table-view>
-			<app-category-charts *ngIf="routeView !== 'table' && sub.requestComplete" [search]="search" [portalSettings]="portalSettings"
-			 [chartStart]="sub.chartStart" [chartEnd]="sub.chartEnd" [dates]="sub.dateArray" [sublist]="sub" [data]="sub.scrollSeries[sub.scrollIndex]"
+			<app-category-charts *ngIf="routeView !== 'table' && displaySeries" [search]="search" [portalSettings]="portalSettings"
+			 [chartStart]="sub.seriesStart" [chartEnd]="sub.seriesEnd" [dates]="sub.dateArray" [sublist]="sub" [data]="sub.scrollSeries[sub.scrollIndex]"
 			 [freq]="data.currentFreq?.freq" [noSeries]="sub.noData" [params]="queryParams"></app-category-charts>
 			<app-series-paging *ngIf="sub.requestComplete" [data]="sub.scrollSeries" (seriesPageChange)="updatePageCounter($event, sub)"></app-series-paging>
 		</ng-template>

--- a/src/app/nta/nta-layout/nta-layout.component.scss
+++ b/src/app/nta/nta-layout/nta-layout.component.scss
@@ -10,7 +10,7 @@
     color: $primary;
   }
 
-  .filters {
+  /* .filters {
     display: inline-block;
     color: $primary;
     margin-bottom: 5px;
@@ -35,6 +35,27 @@
       vertical-align: bottom;
       margin-left: 10px;
       margin-right: 10px;
+    }
+  } */
+
+  .filters {
+    display: inline-block;
+    color: $primary;
+    margin-bottom: 5px;
+    margin-right: 10px;
+
+    .sliders {
+      display: inline-block;
+      width: 360px;
+      vertical-align: bottom;
+      margin-left: 10px;
+      margin-right: 10px;
+
+      @media (max-width: 767px) {
+        display: block;
+        width: 100%;
+        margin: 0;
+      }
     }
   }
 

--- a/src/app/nta/nta-layout/nta-layout.component.ts
+++ b/src/app/nta/nta-layout/nta-layout.component.ts
@@ -22,11 +22,10 @@ export class NtaLayoutComponent implements OnInit, AfterViewInit, AfterViewCheck
   private routeC5ma;
   private search = false;
   private queryParams: any = {};
-  private tableStart;
-  private tableEnd;
-  private chartStart;
-  private chartEnd;
   private chartRange;
+  private seriesStart;
+  private seriesEnd;
+  private displaySeries;
 
   // Variables for geo and freq selectors
   public categoryData;
@@ -103,6 +102,7 @@ export class NtaLayoutComponent implements OnInit, AfterViewInit, AfterViewCheck
 
   // Redraw series when a new measurement is selected
   redrawSeries(event, subId) {
+    this.displaySeries = false;
     this.loading = true;
     setTimeout(() => {
       this.queryParams.m = event.name;
@@ -134,14 +134,11 @@ export class NtaLayoutComponent implements OnInit, AfterViewInit, AfterViewCheck
   }
 
   changeRange(e, measurement) {
-    measurement.tableStart = e.tableStart;
-    measurement.tableEnd = e.tableEnd;
-    measurement.chartStart = e.chartStart;
-    measurement.chartEnd = e.chartEnd;
-    this.tableStart = e.tableStart;
-    this.tableEnd = e.tableEnd;
-    this.chartStart = e.chartStart;
-    this.chartEnd = e.chartEnd;
+    measurement.seriesStart = e.seriesStart;
+    measurement.seriesEnd = e.seriesEnd;
+    this.seriesStart = e.seriesStart;
+    this.seriesEnd = e.seriesEnd;
+    this.displaySeries = true;
   }
 
   // Work around for srolling to page anchor

--- a/src/app/single-series/single-series.component.ts
+++ b/src/app/single-series/single-series.component.ts
@@ -130,7 +130,7 @@ export class SingleSeriesComponent implements OnInit, AfterViewInit {
 
   updateChartExtremes(e) {
     this.chartStart = e.minDate;
-    this.chartEnd = e.endOfSample ? null : e.maxDate;
+    this.chartEnd = e.endOfSample ? null : e.maxDate.substr(0, 4);
   }
 
   // Update table when selecting new ranges in the chart


### PR DESCRIPTION
Fixes the issue where the date sliders were resetting to their default ranges when changing regions.
Also adds input boxes around the sliders where users can enter dates.
Accepted inputs:
Annual: YYYY
Quarterly: YYYY Q#, YYYYQ#, YYYY q#, and YYYYq#,
Monthly/Semiannual: YYYYMM, YYYY-MM