### PR TITLE
Bugfix/ua 1033

### DIFF
--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -337,6 +337,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
     const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);
     const setInputDateParser = (value, freq) => this._highstockHelper.inputDateParserFormatter(value, freq);
+    const setDateToFirstOfMonth = (freq, date) => this._highstockHelper.setDateToFirstOfMonth(freq, date);
     const tableExtremes = this.tableExtremes;
     this.chartOptions.chart = {
       alignTicks: false,
@@ -456,12 +457,14 @@ export class AnalyzerHighstockComponent implements OnChanges {
         afterSetExtremes: function () {
           const userMin = new Date(this.getExtremes().min).toISOString().split('T')[0];
           const userMax = new Date(this.getExtremes().max).toISOString().split('T')[0];
-          this._selectedMin = navigatorOptions.frequency === 'A' ? userMin.substr(0, 4) + '-01-01' : userMin;
-          this._selectedMax = navigatorOptions.frequency === 'A' ? userMax.substr(0, 4) + '-01-01' : userMax;
+          this._selectedMin = setDateToFirstOfMonth(navigatorOptions.frequency, userMin);
+          this._selectedMax = setDateToFirstOfMonth(navigatorOptions.frequency, userMax);
           this._hasSetExtremes = true;
           this._extremes = getChartExtremes(this);
           if (this._extremes) {
             tableExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max });
+            // use setExtremes to snap dates to first of the month
+            this.setExtremes(Date.parse(this._extremes.min), Date.parse(this._extremes.max));
           }
         }
       },

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -66,6 +66,35 @@ export class HighstockHelperService {
     return { min: xMin, max: xMax };
   };
 
+  setDateToFirstOfMonth = (freq, date) => {
+    const month = +date.substr(5, 2);
+    const year = +date.substr(0, 4);
+    if (freq === 'A') {
+      return `${year}-01-01`;
+    }
+    if (freq === 'Q') {
+      return `${year}-${this.getQuarterMonths(month)}-01`;
+    }
+    if (freq === 'M') {
+      return `${date.substr(0, 7)}-01`;
+    }
+  }
+
+  getQuarterMonths = (month) => {
+    if (month >= 1 && month <= 3) {
+      return '01';
+    }
+    if (month >= 4 && month <= 6) {
+      return '04';
+    }
+    if (month >= 7 && month <= 9) {
+      return '07';
+    }
+    if (month >= 10 && month <= 12) {
+      return '10';
+    }
+  }
+
   getTooltipFreqLabel = (frequency, date) => {
     const year = Highcharts.dateFormat('%Y', date);
     const month = Highcharts.dateFormat('%b', date);

--- a/src/app/highstock-helper.service.ts
+++ b/src/app/highstock-helper.service.ts
@@ -75,7 +75,7 @@ export class HighstockHelperService {
     if (freq === 'Q') {
       return `${year}-${this.getQuarterMonths(month)}-01`;
     }
-    if (freq === 'M') {
+    if (freq === 'M' || freq === 'S') {
       return `${date.substr(0, 7)}-01`;
     }
   }

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -177,7 +177,7 @@ export class HighstockComponent implements OnChanges {
     const units = seriesDetail.unitsLabel ? seriesDetail.unitsLabel : seriesDetail.unitsLabelShort;
     const change = seriesDetail.percent ? 'Change' : '% Change';
     const chartRange = chartData.level ? this.getSelectedChartRange(this.start, this.end, chartData.dates, this.defaultRange) : null;
-    const startDate = this.start ? this.start : chartRange ? chartRange.start : null;
+    const startDate = this.start ? this.start : chartRange ? chartRange.start : null;    
     const endDate = this.setEndDate(this.end, chartRange, chartData);
     const series = this.formatChartSeries(chartData, portalSettings, seriesDetail, freq);
     const tableExtremes = this.tableExtremes;
@@ -188,6 +188,7 @@ export class HighstockComponent implements OnChanges {
     const setInputDateFormat = freq => this._highstockHelper.inputDateFormatter(freq);
     const setInputEditDateFormat = freq => this._highstockHelper.inputEditDateFormatter(freq);
     const setInputDateParser = (value, freq) => this._highstockHelper.inputDateParserFormatter(value, freq);
+    const setDateToFirstOfMonth = (freq, date) => this._highstockHelper.setDateToFirstOfMonth(freq, date);
     this.chartOptions.chart = {
       alignTicks: false,
       zoomType: 'x',
@@ -273,14 +274,16 @@ export class HighstockComponent implements OnChanges {
         afterSetExtremes: function () {
           const userMin = new Date(this.getExtremes().min).toISOString().split('T')[0];
           const userMax = new Date(this.getExtremes().max).toISOString().split('T')[0];
-          this._selectedMin = freq.freq === 'A' ? userMin.substr(0, 4) + '-01-01' : userMin;
-          this._selectedMax = freq.freq === 'A' ? userMax.substr(0, 4) + '-01-01' : userMax;
+          this._selectedMin = setDateToFirstOfMonth(freq.freq, userMin);
+          this._selectedMax = setDateToFirstOfMonth(freq.freq, userMax);
           this._hasSetExtremes = true;
           this._extremes = getChartExtremes(this);
           const lastDate = seriesDetail.seriesObservations.observationEnd;
           if (this._extremes) {
             tableExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max });
-            chartExtremes.emit({ minDate: this._extremes.min, maxDate: this._extremes.max, endOfSample: lastDate === this._extremes.max ? true : false })
+            chartExtremes.emit({ minDate: this._extremes.min, maxDate: freq.freq === 'A' ? this._extremes.max.substr(0, 4) : this._extremes.max, endOfSample: lastDate === this._extremes.max ? true : false })
+            // use setExtremes to snap dates to first of the month
+            this.setExtremes(Date.parse(this._extremes.min), Date.parse(this._extremes.max));
           }
         }
       },

--- a/src/app/single-series/single-series.component.ts
+++ b/src/app/single-series/single-series.component.ts
@@ -130,7 +130,7 @@ export class SingleSeriesComponent implements OnInit, AfterViewInit {
 
   updateChartExtremes(e) {
     this.chartStart = e.minDate;
-    this.chartEnd = e.endOfSample ? null : e.maxDate.substr(0, 4);
+    this.chartEnd = e.endOfSample ? null : e.maxDate;
   }
 
   // Update table when selecting new ranges in the chart


### PR DESCRIPTION
On the single series view, for the Q and M frequencies, it looks like the date ranges could change when switching between regions had more to do with the user input boxes converting the wrong date. The chart and table observations looked consistent. Moving the slider in the chart actually lets the user select any day in a given month, say Dec 20; even if on a quarterly series, observations can only land on Jan 1, Apr 1, Jul 1, or Oct 1. So I added a call to Highcharts' setExtremes to force the charts to snap to dates that are available for a particular frequency (i.e. Dec 20 should snap back to Oct 1 in Quarterly or Dec 1 in Monthly series).