### PR TITLE
Bugfix/ua 1112

### DIFF
--- a/src/app/category-table-renderer/category-table-renderer.component.html
+++ b/src/app/category-table-renderer/category-table-renderer.component.html
@@ -1,14 +1,12 @@
 <ng-template ngIf [ngIf]="params.data.lvlData">
   <span>
-    <a class="{{params.data.seriesInfo.indent ? 'indent' + params.data.seriesInfo.indent : ''}}" [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id, sa: params.data.seriesInfo.saParam, seriesCat: params.data.categoryId }"
+    <a class="{{params.data.seriesInfo.indent ? 'indent' + params.data.seriesInfo.indent : ''}}" [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id, sa: params.data.seriesInfo.saParam }"
       queryParamsHandling='merge'>{{params.value}}</a>
   </span>
   <div class="th-buttons">
-    <!-- <i [title]="params.data.seriesInfo.analyze ? 'Remove from Analyzer' : 'Add to Analyzer'" [class.add-button]="!params.data.seriesInfo.analyze"
-      [class.remove-button]="params.data.seriesInfo.analyze" class="material-icons analyzer-toggle remove-button" (click)="updateAnalyze(params.data.seriesInfo)">&#xE838;</i> -->
     <i *ngIf="!params.data.seriesInfo.analyze" title="Add to Analyzer" [class.add-button]="params.data.seriesInfo.analyze" class="material-icons analyzer-toggle" (click)="updateAnalyze(params.data.seriesInfo)">star_border</i>
     <i *ngIf="params.data.seriesInfo.analyze" title="Remove from Analyzer" [class.remove-button]="params.data.seriesInfo.analyze" class="material-icons analyzer-toggle remove-button" (click)="updateAnalyze(params.data.seriesInfo)">star</i>
-    <a tabindex="0" id="{{params.data.subcatIndex + params.data.seriesInfo.id}}" class="info" (click)="showPopover(params.data.seriesInfo, params.data.subcatIndex)"
+    <a tabindex="0" id="{{params.data.seriesInfo.id}}" class="info" (click)="showPopover(params.data.seriesInfo, params.data.subcatIndex)"
       role="button" data-animation='false' data-toggle="popover">
       <i class="material-icons info-icon">&#xE88F;</i>
     </a>

--- a/src/app/category-table-view/category-table-view.component.ts
+++ b/src/app/category-table-view/category-table-view.component.ts
@@ -117,11 +117,10 @@ export class CategoryTableViewComponent implements OnChanges {
   formatLvlData = (series, level, subcatIndex, parentId) => {
     const { dates, values } = level;
     const seriesData = {
-      series: series.seriesInfo.displayName,
+      series: `${series.seriesInfo.tablePrefix} ${series.seriesInfo.displayName} ${series.seriesInfo.tablePostfix}`,
       saParam: series.seriesInfo.saParam,
       seriesInfo: series.seriesInfo,
       lvlData: true,
-      //subcatIndex: subcatIndex,
       categoryId: parentId
     }
     dates.forEach((d, index) => {

--- a/src/app/series-helper.service.ts
+++ b/src/app/series-helper.service.ts
@@ -34,7 +34,8 @@ export class SeriesHelperService {
       seriesTableData: [],
       siblings: [],
       error: null,
-      noData: ''
+      noData: '',
+      requestComplete: false
     };
     const dateArray = [];
     const analyzerSeries = this._analyzer.analyzerSeries;
@@ -70,13 +71,16 @@ export class SeriesHelperService {
         const formattedData = this.dataTransform(obs, dateArray, decimals);
         this.seriesData.chartData = formattedData.chartData;
         this.seriesData.seriesTableData = formattedData.tableData;
+        this.seriesData.requestComplete = true;
       } else {
         this.seriesData.noData = 'Data not available';
+        this.seriesData.requestComplete = true;
       }
     },
       (error) => {
         error = this.errorMessage = error;
         this.seriesData.eror = true;
+        this.seriesData.requestComplete = true;
       });
     return observableForkJoin(observableOf(this.seriesData));
   }

--- a/src/app/single-series/single-series.component.html
+++ b/src/app/single-series/single-series.component.html
@@ -39,7 +39,7 @@
       </div>
     </div>
     <div class="series-table">
-      <p-dataTable *ngIf="!noSelection && !data.noData" [value]="newTableData">
+      <p-dataTable *ngIf="!noSelection && !data.noData" [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'fa-spinner'">
         <p-column field="tableDate" header="Date" [sortable]="true"></p-column>
         <p-column [field]=portalSettings.seriesTable.series1 header="Level"></p-column>
         <p-column [field]=portalSettings.seriesTable.series2 [header]="data.seriesDetail.percent ? portalSettings.seriesTable.series2PercLabel : portalSettings.seriesTable.series2Label"></p-column>

--- a/src/app/single-series/single-series.component.scss
+++ b/src/app/single-series/single-series.component.scss
@@ -101,7 +101,15 @@
 :host {
   ::ng-deep {
     .ui-datatable {
-      background-color: #000;
+      background-color: transparent;
+
+      .fa-spinner {
+        color: $primary;
+        display: block;
+        font-size: 1.3em;
+        margin-top: 20px;    
+      }
+
       th, td {
         text-align: right;
         font-family: 'Lucida Sans', sans-serif;
@@ -114,6 +122,10 @@
         background: #F5F5F5;
         border: 1px solid #E5E5E5;
         border-bottom: 0;
+      }
+
+      .ui-widget-overlay {
+        background-color: transparent;
       }
   
       th.ui-state-active {


### PR DESCRIPTION
- Displays a loading icon in the single series view when waiting for data to load instead of 'No records found.' 
- Also restores the table prefixes and postfixes for the table view. 
   - Example table: category?id=21&data_list_id=44&view=table
   - 'less Contributions for Govt Social Insurance'.
   - If the series name is truncated, the name including any prefix or postfix will display in a tooltip when hovering over the series