### PR TITLE
track data_list_id parameter

### DIFF
--- a/src/app/nta/nta-layout/nta-layout.component.ts
+++ b/src/app/nta/nta-layout/nta-layout.component.ts
@@ -67,6 +67,7 @@ export class NtaLayoutComponent implements OnInit, AfterViewInit, OnDestroy {
       this.selectedMeasure = params['m'];
       if (this.id) { this.queryParams.id = this.id; };
       if (this.selectedMeasure) { this.queryParams.m = this.selectedMeasure; };
+      if (this.dataListId) { this.queryParams.data_list_id = this.dataListId; };
       if (this.routeView) { this.queryParams.view = this.routeView; };
       if (this.routeC5ma) { this.queryParams.c5ma = this.routeC5ma; } else { delete this.queryParams.c5ma; }
       this.categoryData = this._ntaHelper.initContent(this.id, this.dataListId, this.selectedMeasure);


### PR DESCRIPTION
Forgot to add this in the NTA portal to update the `data_list_id` URL parameter 😬 

Steps to replicate error (occurs in production and staging):
- After loading NTA, switch to another category, i.e. wealth aggregates
- Change the dropdown to European Countries
- Click on a different category, i.e. Wealth per capita
- Portal freezes when changing measurements