### PR TITLE
check if date range selected includes end of sample

### DIFF
--- a/src/app/date-slider/date-slider.component.ts
+++ b/src/app/date-slider/date-slider.component.ts
@@ -77,7 +77,8 @@ export class DateSliderComponent implements OnInit, AfterViewInit {
   updateChartsAndTables(from, to, freq: string) {
     const seriesStart = this.formatChartDate(from, freq);
     const seriesEnd = this.formatChartDate(to, freq);
-    this.updateRange.emit({ seriesStart: seriesStart, seriesEnd: seriesEnd });
+    const endOfSample = this.dates[this.dates.length - 1].date === seriesEnd;
+    this.updateRange.emit({ seriesStart: seriesStart, seriesEnd: seriesEnd, endOfSample: endOfSample });
   }
 
   updateRanges(portalSettings, fromIndex: number, toIndex: number, from, to, freq: string) {

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -173,7 +173,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, OnDestroy {
 
   changeRange(e) {
     this.seriesStart = e.seriesStart;
-    this.seriesEnd = e.seriesEnd;
+    this.seriesEnd = e.endOfSample ? null : e.seriesEnd;
     this.displaySeries = true;
   }
 


### PR DESCRIPTION
Allows for the latest observation to be displayed when switching frequencies if the date range selected includes the last observation.
Example:
From At a Glance, switch frequency to quarterly (displays up to 2019 Q1) then to monthly. Changes should allow for the monthly series to display up to 2019-03 instead of 2019-01.