### PR TITLE
Bugfix/ua 1042

### DIFF
--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -81,7 +81,7 @@ export class AnalyzerHighstockComponent implements OnChanges, OnDestroy {
       navigatorOptions = {
         frequency: this._analyzer.checkFrequencies(this.series),
         dateStart: this.allDates[0].date,
-        numberOfObservations: this.allDates.map(date => date.date).filter((d, i, a) => a.indexOf(d) === i).length
+        numberOfObservations: this.filterDatesForNavigator(this.allDates).length
       }
       selectedAnalyzerSeries = this.formatSeriesData(this.series, this.allDates, yAxes, navigatorOptions);
     }
@@ -655,4 +655,11 @@ export class AnalyzerHighstockComponent implements OnChanges, OnDestroy {
     this.geoChecked = e.target.checked;
     this.tooltipOptions.emit({ value: e.target.checked, label: 'geo' });
   };
+
+  filterDatesForNavigator(allDates: Array<any>) {
+    return allDates.map(date => date.date).filter((d, i, a) => {
+      // If mixed frequencies are selected, filter out duplicated dates for annual observations, also check if date range only contains a partial year
+      return i > 0 ? a.indexOf(d) === i && d > a[i - 1] : a.indexOf(d) === i;
+    });
+  }
 }

--- a/src/app/analyzer-table/analyzer-table.component.ts
+++ b/src/app/analyzer-table/analyzer-table.component.ts
@@ -81,17 +81,9 @@ export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges() {
-    // Update table as minDate & maxDate change
-    let tableEnd;
-    for (let i = this.allTableDates.length - 1; i > 0; i--) {
-      if (this.maxDate === this.allTableDates[i].date) {
-        tableEnd = i;
-        break;
-      }
-    }
-    tableEnd = tableEnd ? tableEnd : this.allTableDates.length - 1;
-    const tableStart = this.allTableDates.findIndex(item => item.date === this.minDate);
-    this.columnDefs = this.setTableColumns(this.allTableDates, tableStart, tableEnd);
+    const frequencies = [...new Set(this.series.map((series) => series.seriesDetail.frequencyShort))];
+    const newTableDates = this._analyzer.createAnalyzerDates(this.minDate, this.maxDate, frequencies, []);
+    this.columnDefs = this.setTableColumns(newTableDates);
     this.rows = [];
     this.summaryColumns = this.setSummaryStatColumns();
     if (this.minDate && this.maxDate) {
@@ -174,7 +166,7 @@ export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
     }];
   }
 
-  setTableColumns = (dates, tableStart, tableEnd) => {
+  setTableColumns = (dates) => {
     const columns: Array<any> = [];
     columns.push({
       field: 'series',
@@ -196,7 +188,7 @@ export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
       cellEditor: 'analyzerInteractionsEditor',
       cellClass: 'action-column',
     });
-    const tableDates = dates.slice(tableStart, tableEnd + 1);
+    const tableDates = dates;
     // Reverse dates for right-to-left scrolling on tables
     for (let i = tableDates.length - 1; i >= 0; i--) {
       columns.push({ field: tableDates[i].tableDate, headerName: tableDates[i].tableDate, width: 125 });

--- a/src/app/analyzer-table/analyzer-table.component.ts
+++ b/src/app/analyzer-table/analyzer-table.component.ts
@@ -82,8 +82,10 @@ export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges() {
     const frequencies = [...new Set(this.series.map((series) => series.seriesDetail.frequencyShort))];
-    const newTableDates = this._analyzer.createAnalyzerDates(this.minDate, this.maxDate, frequencies, []);
-    this.columnDefs = this.setTableColumns(newTableDates);
+    if (this.minDate && this.maxDate) {
+      const newTableDates = this._analyzer.createAnalyzerDates(this.minDate, this.maxDate, frequencies, []);
+      this.columnDefs = this.setTableColumns(newTableDates);
+    }
     this.rows = [];
     this.summaryColumns = this.setSummaryStatColumns();
     if (this.minDate && this.maxDate) {

--- a/src/app/analyzer.service.ts
+++ b/src/app/analyzer.service.ts
@@ -126,19 +126,8 @@ export class AnalyzerService {
   }
 
   checkFrequencies = (series) => {
-    let freq = 'A';
-    series.forEach((s) => {
-      if (s.currentFreq.freq === 'M') {
-        freq = 'M';
-      }
-      if (s.currentFreq.freq === 'Q') {
-        freq = 'Q';
-      }
-      if (s.currentFreq.freq === 'S') {
-        freq = 'S';
-      }
-    });
-    return freq;
+    const freqs = series.map((s) => s.currentFreq.freq);
+    return freqs.includes('M') ? 'M' : freqs.includes('Q') ? 'Q' : freqs.includes('S') ? 'S' : 'A'
   }
 
   createAnalyzerTable = (analyzerSeries) => {
@@ -291,7 +280,6 @@ export class AnalyzerService {
       }
       start.setMonth(start.getMonth() + 1);
     }
-    console.log('dateArray', dateArray)
     return dateArray;
   }
 

--- a/src/app/analyzer.service.ts
+++ b/src/app/analyzer.service.ts
@@ -205,13 +205,9 @@ export class AnalyzerService {
   }
 
   setAnalyzerDates(analyzerSeries) {
-    const frequencies = [];
     const dateWrapper = { firstDate: '', endDate: '' };
+    const frequencies = [...new Set(analyzerSeries.map((series) => series.seriesDetail.frequencyShort))];
     analyzerSeries.forEach((series) => {
-      const freqExist = frequencies.find(freq => freq.freq === series.seriesDetail.frequencyShort);
-      if (!freqExist) {
-        frequencies.push({ freq: series.seriesDetail.frequencyShort, label: series.seriesDetail.frequency });
-      }
       // Get earliest start date and latest end date
       this.setDateWrapper(dateWrapper, series.observations.observationStart, series.observations.observationEnd);
     });
@@ -249,16 +245,16 @@ export class AnalyzerService {
     let sSelected = false;
     let mSelected = false;
     frequencies.forEach((freq) => {
-      if (freq.freq === 'A') {
+      if (freq === 'A') {
         aSelected = true;
       }
-      if (freq.freq === 'Q') {
+      if (freq === 'Q') {
         qSelected = true;
       }
-      if (freq.freq === 'S') {
+      if (freq === 'S') {
         sSelected = true;
       }
-      if (freq.freq === 'M') {
+      if (freq === 'M') {
         mSelected = true;
       }
     });
@@ -295,6 +291,7 @@ export class AnalyzerService {
       }
       start.setMonth(start.getMonth() + 1);
     }
+    console.log('dateArray', dateArray)
     return dateArray;
   }
 

--- a/src/app/analyzer/analyzer.component.ts
+++ b/src/app/analyzer/analyzer.component.ts
@@ -12,13 +12,9 @@ import { DataPortalSettingsService } from '../data-portal-settings.service';
   styleUrls: ['./analyzer.component.scss']
 })
 export class AnalyzerComponent implements OnInit {
-  private analyzerTableDates;
-  private analyzerChartSeries;
   private minDate;
   private maxDate;
   private portalSettings;
-  private alertUser;
-  private alertMessage = '';
   private tableYoy;
   private tableYtd;
   private tableC5ma;
@@ -33,11 +29,8 @@ export class AnalyzerComponent implements OnInit {
   constructor(
     @Inject('portal') private portal,
     private _analyzer: AnalyzerService,
-    private _series: SeriesHelperService,
     private _dataPortalSettings: DataPortalSettingsService,
     private route: ActivatedRoute,
-    private _router: Router,
-    private _helper: HelperService
   ) { }
 
   ngOnInit() {


### PR DESCRIPTION
Fix for the range of dates displayed in the analyzer. Currently, if the user selects mixed frequencies (i.e. annual and quarterly series), the table may not show the full range of data I.e. for /analyzer?analyzerSeries=150129-150383&chartSeries=150129-150383&start=1949-10-01&end=2017-10-01, the annual 2017 observation is cutoff in the table. Adding a semiannual series also generated too many extra dates.