### PR TITLE
turn off highstock turbo threshhold

### DIFF
--- a/src/app/HighstockObject.ts
+++ b/src/app/HighstockObject.ts
@@ -117,6 +117,7 @@ export interface HighstockObject {
   plotOptions: {
     series: {
       cropThreshold: number,
+      turboThreshold?: number,
     }
   },
   series: Array<any>

--- a/src/app/analyzer-highstock/analyzer-highstock.component.ts
+++ b/src/app/analyzer-highstock/analyzer-highstock.component.ts
@@ -524,7 +524,8 @@ export class AnalyzerHighstockComponent implements OnChanges, OnDestroy {
     this.chartOptions.yAxis = yAxis;
     this.chartOptions.plotOptions = {
       series: {
-        cropThreshold: 0
+        cropThreshold: 0,
+        turboThreshold: 0
       }
     };
     this.chartOptions.series = series;

--- a/src/app/highstock/highstock.component.ts
+++ b/src/app/highstock/highstock.component.ts
@@ -345,7 +345,10 @@ export class HighstockComponent implements OnChanges {
       showLastLabel: true
     }];
     this.chartOptions.plotOptions = {
-      series: { cropThreshold: 0 }
+      series: {
+        cropThreshold: 0,
+        turboThreshold: 0
+      }
     };
     this.chartOptions.series = series;
   }


### PR DESCRIPTION
Fix for weekly series charts drawing over the y-axes (i.e. /series?id=153501)