### PR TITLE
set default to show seasonally adjusted series

### DIFF
--- a/src/app/category-charts/category-charts.component.ts
+++ b/src/app/category-charts/category-charts.component.ts
@@ -46,8 +46,8 @@ export class CategoryChartsComponent implements OnChanges {
           chartSeries.seriesInfo.analyze = this._analyzer.checkAnalyzer(chartSeries.seriesInfo);
         }
       });
-      this.noSeriesToDisplay = this._helper.checkIfSeriesAvailable(this.noSeries, this.data);
     }
+    this.noSeriesToDisplay = this._helper.checkIfSeriesAvailable(this.noSeries, this.data);
     // If setYAxes, chart view should display all charts' (level) yAxis with the same range
     // Allow y-axes to vary for search results
     if (this.portalSettings.highcharts.setYAxes && !this.search) {

--- a/src/app/category-table-view/category-table-view.component.ts
+++ b/src/app/category-table-view/category-table-view.component.ts
@@ -54,9 +54,10 @@ export class CategoryTableViewComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    this.columnDefs = this.setTableColumns(this.dates, this.freq, this.defaultRange, this.tableStart, this.tableEnd);
+    //this.columnDefs = this.setTableColumns(this.dates, this.freq, this.defaultRange, this.tableStart, this.tableEnd);
     this.rows = [];
     if (this.data) {
+      this.columnDefs = this.setTableColumns(this.dates, this.freq, this.defaultRange, this.tableStart, this.tableEnd);
       this.data.forEach((series) => {
         if (series.seriesInfo !== 'No data available' && this.dates) {
           series.display = this._helper.toggleSeriesForSeasonalDisplay(series, this.showSeasonal, this.hasNonSeasonal);
@@ -79,8 +80,8 @@ export class CategoryTableViewComponent implements OnChanges {
           }
         }
       });
-      this.noSeriesToDisplay = this._helper.checkIfSeriesAvailable(this.noSeries, this.data);
     }
+    this.noSeriesToDisplay = this._helper.checkIfSeriesAvailable(this.noSeries, this.data);
   }
 
   setTableColumns = (dates, freq, defaultRange, tableStart, tableEnd) => {

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -89,7 +89,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit, OnDestroy {
       if (this.routeGeo) { this.queryParams.geo = this.routeGeo; };
       if (this.routeFreq) { this.queryParams.freq = this.routeFreq; };
       if (this.routeView) { this.queryParams.view = this.routeView; };
-      if (this.routeSa) { this.queryParams.sa = this.routeSa; } else { delete this.queryParams.sa; }
+      if (this.routeSa) { this.queryParams.sa = this.routeSa; } else { this.queryParams.sa = 'true'; }
       if (this.routeYoy) { this.queryParams.yoy = this.routeYoy; } else { delete this.queryParams.yoy; }
       if (this.routeYtd) { this.queryParams.ytd = this.routeYtd; } else { delete this.queryParams.ytd; }
       if (this.noCache) { this.queryParams.noCache = this.noCache; } else { delete this.queryParams.noCache; }


### PR DESCRIPTION
Defaults to displaying seasonally adjusted series for the category views.
Also a bug fix when navigating to a category with no series (i.e. https://data.uhero.hawaii.edu/#/category?geo=HI&freq=S), chart and table views aren't correctly displaying a warning that no series are available.