### PR TITLE
add an outage.html to each data portal dist build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,8 @@
             },
             "assets": [
               "src/assets",
-              "src/manoa.jpg"
+              "src/manoa.jpg",
+              "src/outage.html"
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",
@@ -156,7 +157,8 @@
             },
             "assets": [
               "src/assets",
-              "src/manoa.jpg"
+              "src/manoa.jpg",
+              "src/outage.html"
             ]
           }
         },
@@ -225,7 +227,8 @@
             },
             "assets": [
               "src/assets",
-              "src/nta-logo.png"
+              "src/nta-logo.png",
+              "src/outage.html"
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",
@@ -356,7 +359,8 @@
             },
             "assets": [
               "src/assets",
-              "src/nta-logo.png"
+              "src/nta-logo.png",
+              "src/outage.html"
             ]
           }
         },
@@ -425,7 +429,8 @@
             },
             "assets": [
               "src/assets",
-              "src/hawaii-county-seal.png"
+              "src/hawaii-county-seal.png",
+              "src/outage.html"
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.css",
@@ -556,7 +561,8 @@
             },
             "assets": [
               "src/assets",
-              "src/hawaii-county-seal.png"
+              "src/hawaii-county-seal.png",
+              "src/outage.html"
             ]
           }
         },

--- a/src/outage.html
+++ b/src/outage.html
@@ -11,7 +11,7 @@
 <body>
   <div style='text-align: center;'>
     <h1>Please try again</h1>
-    The data portal is currently down for maintainence. Please try again in a little while. <br/>
+    The data portal is currently down for maintenance. Please try again in a little while. <br/>
     We apologize for the inconvenience.
   </div>
 </body>

--- a/src/outage.html
+++ b/src/outage.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <link id="favicon" rel="icon" type="image/jpg">
+</head>
+<body>
+  <div style='text-align: center;'>
+    <h1>Please try again</h1>
+    The data portal is currently down for maintainence. Please try again in a little while. <br/>
+    We apologize for the inconvenience.
+  </div>
+</body>
+</html>


### PR DESCRIPTION
I made the text in the outage file a little more generic to just say 'The data portal...' is down for maintenance. I can make it more specific to each portal (i.e. 'NTA data portal is currently down...', 'UHERO data portal is currently down...', etc) with the coming [upgrade](https://uhero-analytics.atlassian.net/browse/UA-1284) to the data portal  