### PR TITLE
enable SA toggle only if SA series are available

### DIFF
--- a/projects/tools/src/lib/category-charts/category-charts.component.ts
+++ b/projects/tools/src/lib/category-charts/category-charts.component.ts
@@ -17,6 +17,7 @@ export class CategoryChartsComponent implements OnChanges {
   @Input() noSeries;
   @Input() showSeasonal;
   @Input() hasNonSeasonal;
+  @Input() hasSeasonal;
   @Input() nsaActive;
   @Input() yoyActive;
   @Input() ytdActive;
@@ -43,7 +44,7 @@ export class CategoryChartsComponent implements OnChanges {
     if (this.data) {
       this.data.forEach((chartSeries) => {
         if (chartSeries.seriesInfo !== 'No data available' && this.dates) {
-          chartSeries.display = this.helperService.toggleSeriesForSeasonalDisplay(chartSeries, this.showSeasonal, this.hasNonSeasonal);
+          chartSeries.display = this.helperService.toggleSeriesForSeasonalDisplay(chartSeries, this.showSeasonal, this.hasSeasonal);
           chartSeries.categoryDisplay = this.formatCategoryChartData(chartSeries.seriesInfo.seriesObservations, this.dates, this.portalSettings);
           chartSeries.seriesInfo.analyze = this.analyzerService.checkAnalyzer(chartSeries.seriesInfo);
         }

--- a/projects/tools/src/lib/category-helper.service.ts
+++ b/projects/tools/src/lib/category-helper.service.ts
@@ -116,7 +116,7 @@ export class CategoryHelperService {
         const displaySeries = this.filterSeriesResults(series);
         this.categoryData[cacheId].displaySeries = displaySeries.length ? displaySeries : null;
         this.categoryData[cacheId].series = series;
-        this.categoryData[cacheId].hasNonSeasonal = this.findNonSeasonalSeries(displaySeries);
+        this.categoryData[cacheId].hasSeasonal = this.findSeasonalSeries(displaySeries);
         this.categoryData[cacheId].requestComplete = true;
       }
       if (!expandedCategory) {
@@ -236,7 +236,7 @@ export class CategoryHelperService {
       this.categoryData[cacheId].currentFreq = results.freqs.find(f => f.freq === freq);
       const displaySeries = this.filterSeriesResults(results.series);
       this.categoryData[cacheId].displaySeries = displaySeries.length ? displaySeries : null;
-      this.categoryData[cacheId].hasNonSeasonal = this.findNonSeasonalSeries(displaySeries);
+      this.categoryData[cacheId].hasSeasonal = this.findSeasonalSeries(displaySeries);
       const catWrapper = this.getSearchDates(displaySeries);
       const categoryDateArray = [];
       this.helperService.createDateArray(catWrapper.firstDate, catWrapper.endDate, freq, categoryDateArray);
@@ -268,7 +268,7 @@ export class CategoryHelperService {
       const levelData = res.seriesObservations.transformationResults[0].dates;
       if (levelData) {
         const series = { seriesInfo: { displayName: '' } };
-        res.saParam = res.seasonalAdjustment !== 'not_seasonally_adjusted';
+        res.saParam = res.seasonalAdjustment === 'seasonally_adjusted';
         series.seriesInfo = res;
         series.seriesInfo.displayName = res.title;
         filtered.push(series);
@@ -277,9 +277,7 @@ export class CategoryHelperService {
     return filtered;
   }
 
-  findNonSeasonalSeries = (categorySeries: Array<any>) => {
-    return categorySeries.some(s => s.seriesInfo.seasonalAdjustment === 'not_seasonally_adjusted');
-  }
+  findSeasonalSeries = (categorySeries: Array<any>) => categorySeries.some(s => s.seriesInfo.seasonalAdjustment === 'seasonally_adjusted');
 
   getDisplaySeries(allSeries) {
     // Check if (non-annual) category has seasonally adjusted data

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.html
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.html
@@ -6,7 +6,7 @@
     <i class="far fa-file-excel"></i>
   </button>
   <ag-grid-angular style="width: 100%;" class="ag-theme-balham" [rowData]="rows" [columnDefs]="columnDefs"
-    domLayout="autoHeight" [frameworkComponents]="frameworkComponents" [enableRtl]="true"
+    domLayout="autoHeight" [frameworkComponents]="frameworkComponents" [gridOptions]="gridOptions" [enableRtl]="true"
     (gridReady)="onGridReady($event)">
   </ag-grid-angular>
 </ng-template>

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.ts
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.ts
@@ -30,6 +30,7 @@ export class CategoryTableViewComponent implements OnChanges {
   @Input() seriesInAnalyzer;
   @Input() showSeasonal: boolean;
   @Input() hasNonSeasonal: boolean;
+  @Input() hasSeasonal;
   private gridApi;
   columnDefs;
   rows;
@@ -42,6 +43,7 @@ export class CategoryTableViewComponent implements OnChanges {
   disablePrevious: boolean;
   disableNext: boolean;
   noSeriesToDisplay;
+  gridOptions;
 
   constructor(
     @Inject('defaultRange') private defaultRange,
@@ -55,11 +57,16 @@ export class CategoryTableViewComponent implements OnChanges {
 
   ngOnChanges() {
     this.rows = [];
+    this.gridOptions = {
+      localeText: {
+        noRowsToShow: 'Current selections do not return any data, please try a different combination'
+      }
+    };
     if (this.data) {
       this.columnDefs = this.setTableColumns(this.dates, this.freq, this.defaultRange, this.tableStart, this.tableEnd);
       this.data.forEach((series) => {
         if (series.seriesInfo !== 'No data available' && this.dates) {
-          series.display = this.helperService.toggleSeriesForSeasonalDisplay(series, this.showSeasonal, this.hasNonSeasonal);
+          series.display = this.helperService.toggleSeriesForSeasonalDisplay(series, this.showSeasonal, this.hasSeasonal);
           series.seriesInfo.analyze = this.analyzerService.checkAnalyzer(series.seriesInfo);
           const transformations = this.helperService.getTransformations(series.seriesInfo.seriesObservations);
           const { level, yoy, ytd, c5ma } = transformations;

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -17,9 +17,9 @@ export class HelperService {
     this.categoryData.next(data);
   }
 
-  toggleSeriesForSeasonalDisplay = (series: any, showSeasonal: boolean, hasNonSeasonal: boolean) => {
-    if (!hasNonSeasonal) {
-      return true; // Display all series if no non-seasonal series exists
+  toggleSeriesForSeasonalDisplay = (series: any, showSeasonal: boolean, hasSeasonal: boolean) => {
+    if (!hasSeasonal) {
+      return true;
     }
     if (series.seriesInfo.seasonalAdjustment !== 'seasonally_adjusted' && !showSeasonal) {
       return true;

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -39,7 +39,7 @@
 					<input type="checkbox" [checked]="queryParams.ytd === 'true'"
 						(change)="ytdActive($event)">Year-to-Date
 				</label>
-				<label *ngIf="data.hasNonSeasonal" class="form-check-inline">
+				<label *ngIf="data.hasSeasonal" class="form-check-inline">
 					<input type="checkbox" name="seasonal_toggle" [checked]="queryParams.sa === 'true'"
 						(change)="toggleSASeries($event)">Seasonally Adjusted
 				</label>
@@ -55,13 +55,13 @@
 		[selectedCategory]="data.selectedCategory" [selectedDataList]="data.selectedDataList" [data]="data.displaySeries"
 		[geo]="data.currentGeo" [freq]="data.currentFreq?.freq" [freqLabel]="data.currentFreq?.label"
 		[yoyActive]="queryParams.yoy === 'true'" [ytdActive]="queryParams.ytd === 'true'" [noSeries]="data.noData"
-		[params]="queryParams" [showSeasonal]="queryParams.sa === 'true'" [hasNonSeasonal]="data.hasNonSeasonal" [seriesInAnalyzer]="seriesInAnalyzer">
+		[params]="queryParams" [showSeasonal]="queryParams.sa === 'true'" [hasSeasonal]="data.hasSeasonal" [seriesInAnalyzer]="seriesInAnalyzer">
 		</lib-category-table-view>
 		<lib-category-charts *ngIf="routeView !== 'table' && data.requestComplete" [portalSettings]="portalSettings"
 		[chartStart]="seriesStart" [chartEnd]="seriesEnd" [data]="data.displaySeries"
 		[selectedDataList]="data.selectedDataList" [dateWrapper]="data.categoryDateWrapper" [dates]="data.categoryDates"
 		[freq]="data.currentFreq?.freq" [noSeries]="data.noData" [seriesInAnalyzer]="seriesInAnalyzer"
-		[showSeasonal]="queryParams.sa === 'true'" [hasNonSeasonal]="data.hasNonSeasonal" (updateURLFragment)="updateRoute()">
+		[showSeasonal]="queryParams.sa === 'true'" [hasSeasonal]="data.hasSeasonal" (updateURLFragment)="updateRoute()">
 		</lib-category-charts>
 	</ng-template>
 </div>

--- a/projects/tools/src/lib/landing-page/landing-page.component.scss
+++ b/projects/tools/src/lib/landing-page/landing-page.component.scss
@@ -15,7 +15,6 @@
 
     .sliders {
       display: inline-block;
-      width: 360px;
       vertical-align: bottom;
       margin-left: 10px;
       margin-right: 10px;

--- a/projects/tools/src/lib/measurement-landing-page/measurement-landing-page.component.scss
+++ b/projects/tools/src/lib/measurement-landing-page/measurement-landing-page.component.scss
@@ -16,7 +16,6 @@
 
     .sliders {
       display: inline-block;
-      width: 360px;
       vertical-align: bottom;
       margin-left: 10px;
       margin-right: 10px;


### PR DESCRIPTION
Changes to make the seasonal adjustment checkbox only appear if there are both seasonal and non-seasonal series (or series where seasonality is not applicable) for a category. Otherwise, all available series should appear.