### PR TITLE
fix for quarterly analyzer dates

### DIFF
--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -243,7 +243,7 @@ export class HelperService {
       return year;
     }
     if (freq === 'Q') {
-      const m = new Date(date).getMonth();
+      const m = +month;
       if (m >= 0 && m <= 2) {
         return `${year} Q1`;
       }
@@ -258,7 +258,7 @@ export class HelperService {
       }
     }
     if (freq === 'M' || freq === 'S') {
-      return  year + '-' + month;
+      return `${year}-${month}`;
     }
     return date.substr(0, 10);
   }


### PR DESCRIPTION
Fix for error with quarterly dates in analyzer table. (/#/analyzer?analyzerSeries=153460-153462-153464-153466-153468-153470&chartSeries=153460-153462-153464-153466-153468-153470&start=2008-10-01&end=2020-01-01&units=true)