### PR TITLE
workaround for sliders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9888,9 +9888,9 @@
       "integrity": "sha512-JQBIswGSItn8I0Pq21RchENpKJxSi1MjfBDfggMQpXtoKNKblJoHmol/7tCV3CAV2Dlb94ht8TD8qdIAW01pGg=="
     },
     "primeng": {
-      "version": "10.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-10.0.0-rc.4.tgz",
-      "integrity": "sha512-aPQC3rUAtum471jmr4oOeU19Af6G9aOMz6fQ3zge4Qc6zgNpmh0b6LWtCJI6PQf8iYTsE+I5rrlJLZQZuq4tPQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-10.0.0.tgz",
+      "integrity": "sha512-3W2AN6YvSPC9v78XgGQ/xJ7e4aQR1vECVXQioy5Av5sxM7LBB4aEgqnQt5jCxMXl/NDXTVIsjKVWIVvl/nPsXA==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jquery": "^3.4.1",
     "popper.js": "^1.16.1",
     "primeicons": "^4.0.0",
-    "primeng": "^10.0.0-rc.4",
+    "primeng": "^10.0.0",
     "rxjs": "~6.6.2",
     "tether": "^1.4.7",
     "tslib": "^2.0.0",

--- a/projects/tools/src/lib/date-slider/date-slider.component.ts
+++ b/projects/tools/src/lib/date-slider/date-slider.component.ts
@@ -55,6 +55,9 @@ export class DateSliderComponent implements OnInit {
   slideChange(e) {
     this.start = e.values[0];
     this.end = e.values[1];
+    // workaround for onSlideEnd not firing when not using the slide handles
+    this.sliderSelectedRange = [this.start, this.end];
+    this.updateChartsAndTables(this.sliderDates[this.start], this.sliderDates[this.end], this.freq);
   }
 
   slideEnd(e) {
@@ -77,7 +80,10 @@ export class DateSliderComponent implements OnInit {
 
   checkValidInputString = (value, freq: string) => {
     // Accepted input formats:
-    // Annual: YYYY; Quarterly: YYYY Q#, YYYYQ#, YYYY q#, YYYYq#; Monthly/Semiannual: YYYY-MM, YYYYMM
+    // Annual: YYYY
+    // Quarterly: YYYY Q#, YYYYQ#, YYYY q#, YYYYq#
+    // Monthly/Semiannual: YYYY-MM, YYYYMM
+    // Weekly: YYYY-MM-DD
     if (freq === 'A') {
       return /^\d{4}$/.test(value);
     }
@@ -86,6 +92,9 @@ export class DateSliderComponent implements OnInit {
     }
     if (freq === 'M' || freq === 'S') {
       return /^\d{4}(|-)\d{2}$/.test(value);
+    }
+    if (freq === 'W') {
+      return /^\d{4}(|-)\d{2}(|-)\d{2}$/.test(value);
     }
   }
 


### PR DESCRIPTION
Temp workaroung for a bug in the latest version of the primeng slider prevents the date ranges in the charts and tables from changing if the user just clicks along bar to update the slider rather than actually clicking and dragging the handles.