### PR TITLE
fix for embedded analyzer charts

### DIFF
--- a/projects/tools/src/lib/embed-graph/embed-graph.component.ts
+++ b/projects/tools/src/lib/embed-graph/embed-graph.component.ts
@@ -22,7 +22,7 @@ export class EmbedGraphComponent implements OnInit {
   tooltipGeo: boolean = true;
   tooltipName: boolean = true;
   tooltipUnits: boolean = true;
-  indexSeries: boolean = true;
+  indexSeries: boolean;
   
   constructor(
     @Inject('portal') public portal,


### PR DESCRIPTION
Error in variable declaration made all embedded analyzer charts display indexed series.