### PR TITLE
add link to high frequency dashboard

### DIFF
--- a/projects/tools/src/lib/data-portal-settings.service.ts
+++ b/projects/tools/src/lib/data-portal-settings.service.ts
@@ -48,7 +48,8 @@ export class DataPortalSettingsService {
         ytd: false,
         c5ma: true
       },
-      sliderInteraction: false
+      sliderInteraction: false,
+      otherDashboardLinks: []
     },
     uhero: {
       catTable: {
@@ -96,7 +97,13 @@ export class DataPortalSettingsService {
         ytd: true,
         c5ma: false
       },
-      sliderInteraction: true
+      sliderInteraction: true,
+      otherDashboardLinks: [
+        {
+          name: `Hawai'i High Frequency Economic Data`,
+          url: `https://data.uhero.hawaii.edu/high-frequency-dashboard/#/`
+        }
+      ]
     },
     ccom: {
       catTable: {
@@ -144,7 +151,8 @@ export class DataPortalSettingsService {
         ytd: true,
         c5ma: false
       },
-      sliderInteraction: true
+      sliderInteraction: true,
+      otherDashboardLinks: []
     },
     coh: {
       catTable: {
@@ -192,7 +200,8 @@ export class DataPortalSettingsService {
         ytd: true,
         c5ma: false
       },
-      sliderInteraction: true
+      sliderInteraction: true,
+      otherDashboardLinks: []
     }
   };
 }

--- a/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.html
+++ b/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.html
@@ -16,6 +16,9 @@
     <a class="list-item" [class.selectedCategory]="selectedCategory === 'analyzer'" routerLink="/analyzer">&nbsp; Analyzer ({{analyzerSeries}})</a>
     <a class="list-item" id="about-link" [class.selectedCategory]="selectedCategory === 'help'"
       routerLink="/help">&nbsp; About</a>
+    <ng-template ngFor let-dashboard [ngForOf]="portalSettings.otherDashboardLinks">
+      <a *ngIf="dashboard.name" class="list-item" [attr.href]="dashboard.url">{{dashboard.name}}</a>  
+    </ng-template> 
     <span *ngIf="headerLogo.analyticsLogoSrc">
       <p id="built-by">Built By</p>
       <a href="https://uhero.hawaii.edu/uhero-analytics/"><img class="analytics-logo"

--- a/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
+++ b/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { AnalyzerService } from '../analyzer.service';
 import { ApiService } from '../api.service';
 import { MenuItem } from 'primeng/api';
+import { DataPortalSettingsService } from '../data-portal-settings.service';
 
 @Component({
   selector: 'lib-primeng-menu-nav',
@@ -26,12 +27,14 @@ export class PrimengMenuNavComponent implements OnInit, OnDestroy {
   private packageCatData;
   private expand = true;
   analyzerSeriesCount;
-
+  portalSettings;
   navMenuItems: MenuItem[];
 
   constructor(
     @Inject('logo') private logo,
     private apiService: ApiService,
+    private dataPortalSettingsServ: DataPortalSettingsService,
+    @Inject('portal') private portal,
     public analyzerService: AnalyzerService,
     private activatedRoute: ActivatedRoute,
     private router: Router
@@ -39,6 +42,7 @@ export class PrimengMenuNavComponent implements OnInit, OnDestroy {
     this.analyzerSeriesCount = this.analyzerService.analyzerSeriesCount$.subscribe((data: any) => {
       this.analyzerSeries = data;
     });
+    this.portalSettings = this.dataPortalSettingsServ.dataPortalSettings[this.portal.universe];
   }
 
   ngOnInit() {


### PR DESCRIPTION
Add links to other dashboards in the left navigation bar. (Currently just adds the high frequency dashboard link to the UHERO portal)