### PR TITLE
fix analyzer comparison chart type settings

### DIFF
--- a/projects/tools/src/lib/analyzer.service.ts
+++ b/projects/tools/src/lib/analyzer.service.ts
@@ -163,7 +163,7 @@ export class AnalyzerService {
   findSelectedCompareSeries = (seriesId) => {
     const { analyzerSeries } = this.analyzerData;
     const compareSeries = analyzerSeries.filter(s => s.visible);
-    return compareSeries.find(s => s.className = seriesId);
+    return compareSeries.find(s => s.className === seriesId);
   }
 
   updateCompareChartType(seriesId: number, chartType: string) {


### PR DESCRIPTION
Fixed an error where only the first series in the analyzer comparison view could have its chart type (line, bar, area) changed.