### PR TITLE
Bugfix/u 1503

### DIFF
--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -1,16 +1,22 @@
 import {
   Component,
   Inject,
+  OnInit,
+  OnDestroy,
   OnChanges,
   Input,
   Output,
   EventEmitter,
   ChangeDetectionStrategy,
   ViewEncapsulation,
+  SimpleChanges
 } from '@angular/core';
 import { AnalyzerService } from '../analyzer.service';
+import { DateRange } from '../tools.models';
 import { Dropdown } from 'bootstrap';
 import { HighstockHelperService } from '../highstock-helper.service';
+import { HelperService } from '../helper.service';
+import { Subscription } from 'rxjs';
 import * as Highcharts from 'highcharts/highstock';
 import exporting from 'highcharts/modules/exporting';
 import exportData from 'highcharts/modules/export-data';
@@ -26,11 +32,11 @@ type CustomSeriesOptions = Highcharts.SeriesOptionsType & {frequencyShort: strin
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
-export class AnalyzerHighstockComponent implements OnChanges {
+export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy {
   @Input() series;
   @Input() portalSettings;
-  @Input() start;
-  @Input() end;
+  //@Input() start;
+  //@Input() end;
   @Input() dates;
   @Input() indexChecked;
   @Output() xAxisExtremes = new EventEmitter(true);
@@ -42,6 +48,8 @@ export class AnalyzerHighstockComponent implements OnChanges {
   indexed: boolean = false;
   analyzerData;
   oneToOneFlag = false;
+  dateRangeSubscription: Subscription;
+  selectedDateRange: DateRange;
 
   chartCallback = (chart) => {
     if (!this.chartObject) {
@@ -243,6 +251,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     @Inject('logo') private logo,
     private highstockHelper: HighstockHelperService,
     private analyzerService: AnalyzerService,
+    private helperService: HelperService
   ) {
     this.analyzerData = this.analyzerService.analyzerData;
     Highcharts.addEvent(Highcharts.Chart, 'render', e => {
@@ -285,17 +294,17 @@ export class AnalyzerHighstockComponent implements OnChanges {
           addToComparisonChartItem.addEventListener('click', (e) => {
             e.stopPropagation();
             if (chartOptionSeries) {
-              analyzerService.makeCompareSeriesVisible(chartOptionSeries, this.start);
+              analyzerService.makeCompareSeriesVisible(chartOptionSeries, this.selectedDateRange.startDate);
               this.updateUrl.emit(chartOptionSeries);
             }
           });
           removeFromComparisonChartItem.addEventListener('click', () => {
-            analyzerService.removeFromComparisonChart(seriesId, this.start);
+            analyzerService.removeFromComparisonChart(seriesId, this.selectedDateRange.startDate);
             this.updateUrl.emit(chartOptionSeries);
           });
           removeFromAnalyzerItem.addEventListener('click', (e) => {
             e.stopPropagation();
-            analyzerService.removeFromAnalyzer(seriesId, this.start);
+            analyzerService.removeFromAnalyzer(seriesId, this.selectedDateRange.startDate);
           });
         }
       });
@@ -315,13 +324,40 @@ export class AnalyzerHighstockComponent implements OnChanges {
     });
   }
 
-  ngOnChanges() {
-    this.updateChartOptions(this.series);
+  ngOnInit(): void {
+    this.dateRangeSubscription = this.helperService.currentDateRange.subscribe((dateRange) => {
+      this.selectedDateRange = dateRange;
+      const { startDate, endDate } = dateRange;
+      this.drawChart(startDate, endDate);
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const indexCheckChange = changes['indexChecked'];
+    const seriesChange = changes['series']; 
+    const datesChange = changes['dates'];
+    if (
+      (indexCheckChange && !indexCheckChange.firstChange) ||
+      (seriesChange && !seriesChange.firstChange) ||
+      (datesChange && !datesChange.firstChange)
+    ) {
+      const { startDate, endDate } = this.selectedDateRange;
+      this.drawChart(startDate, endDate)
+    }
+
+  }
+
+  ngOnDestroy(): void {
+    this.dateRangeSubscription.unsubscribe();
+  }
+
+  drawChart(startDate: string, endDate: string) {
+    this.updateChartOptions(this.series, startDate, endDate);
     this.updateChart = true;
     if (this.chartOptions.xAxis) {
-      (<Highcharts.AxisOptions>this.chartOptions.xAxis).min = this.start ? Date.parse(this.start) : undefined;
-      (<Highcharts.AxisOptions>this.chartOptions.xAxis).max = this.end ? Date.parse(this.end) : undefined;
-      this.chartObject?.xAxis[0].setExtremes(Date.parse(this.start), Date.parse(this.end));
+      (<Highcharts.AxisOptions>this.chartOptions.xAxis).min = Date.parse(startDate);
+      (<Highcharts.AxisOptions>this.chartOptions.xAxis).max = Date.parse(endDate);
+      this.chartObject?.xAxis[0].setExtremes(Date.parse(startDate), Date.parse(endDate));
       this.setYMinMax();
     }
   }
@@ -339,10 +375,10 @@ export class AnalyzerHighstockComponent implements OnChanges {
     return { items: labelItems, style: { display: 'none' } };
   }
 
-  updateChartOptions(series) {
+  updateChartOptions(series, startDate: string, endDate: string) {
     const { portal, portalLink } = this.portalSettings.highstock.labels;
-    const startDate = this.start || null;
-    const endDate = this.end || null;
+    //const startDate = this.start || null;
+    //const endDate = this.end || null;
     const xAxisFormatter = (chart, freq) => this.highstockHelper.xAxisLabelFormatter(chart, freq);
     const xAxisExtremes = this.xAxisExtremes;
     const logo = this.logo;

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -31,6 +31,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
   @Input() portalSettings;
   @Input() start;
   @Input() end;
+  @Input() dates;
   @Input() indexChecked;
   @Output() xAxisExtremes = new EventEmitter(true);
   @Output() updateUrl = new EventEmitter<any>();
@@ -284,17 +285,17 @@ export class AnalyzerHighstockComponent implements OnChanges {
           addToComparisonChartItem.addEventListener('click', (e) => {
             e.stopPropagation();
             if (chartOptionSeries) {
-              analyzerService.makeCompareSeriesVisible(chartOptionSeries);
+              analyzerService.makeCompareSeriesVisible(chartOptionSeries, this.start);
               this.updateUrl.emit(chartOptionSeries);
             }
           });
           removeFromComparisonChartItem.addEventListener('click', () => {
-            analyzerService.removeFromComparisonChart(seriesId);
+            analyzerService.removeFromComparisonChart(seriesId, this.start);
             this.updateUrl.emit(chartOptionSeries);
           });
           removeFromAnalyzerItem.addEventListener('click', (e) => {
             e.stopPropagation();
-            analyzerService.removeFromAnalyzer(seriesId);
+            analyzerService.removeFromAnalyzer(seriesId, this.start);
           });
         }
       });
@@ -347,6 +348,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const logo = this.logo;
     const highestFreq = this.analyzerService.getHighestFrequency(this.series).freq;
     const buttons = this.formatChartButtons(this.portalSettings.highstock.buttons);
+    const dates = this.dates;
     const rangeSelectorSetExtremes = (eventMin, eventMax, freq, dates, xAxisExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, dates, xAxisExtremes);
     this.chartOptions.accessibility.description = `${portal}\n${portalLink}`;
     this.chartOptions.series = series.map((s, index) => {
@@ -489,7 +491,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
       events: {
         setExtremes: function(e) {
           if (e.trigger === 'rangeSelectorButton') {
-            rangeSelectorSetExtremes(e.min, e.max, highestFreq, [], xAxisExtremes);
+            rangeSelectorSetExtremes(e.min, e.max, highestFreq, dates, xAxisExtremes);
           }
         },
       },

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -347,6 +347,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const logo = this.logo;
     const highestFreq = this.analyzerService.getHighestFrequency(this.series).freq;
     const buttons = this.formatChartButtons(this.portalSettings.highstock.buttons);
+    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, tableExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, tableExtremes);
     this.chartOptions.accessibility.description = `${portal}\n${portalLink}`;
     this.chartOptions.series = series.map((s, index) => {
       return {
@@ -488,7 +489,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
       events: {
         setExtremes: function(e) {
           if (e.trigger === 'rangeSelectorButton') {
-            HighstockHelperService.rangeSelectorSetExtremesEvent(e.min, e.max, highestFreq, tableExtremes);
+            rangeSelectorSetExtremes(e.min, e.max, highestFreq, tableExtremes);
           }
         },
       },

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -35,8 +35,6 @@ type CustomSeriesOptions = Highcharts.SeriesOptionsType & {frequencyShort: strin
 export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy {
   @Input() series;
   @Input() portalSettings;
-  //@Input() start;
-  //@Input() end;
   @Input() dates;
   @Input() indexChecked;
   @Output() xAxisExtremes = new EventEmitter(true);
@@ -344,7 +342,6 @@ export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy 
       const { startDate, endDate } = this.selectedDateRange;
       this.drawChart(startDate, endDate)
     }
-
   }
 
   ngOnDestroy(): void {
@@ -377,8 +374,6 @@ export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy 
 
   updateChartOptions(series, startDate: string, endDate: string) {
     const { portal, portalLink } = this.portalSettings.highstock.labels;
-    //const startDate = this.start || null;
-    //const endDate = this.end || null;
     const xAxisFormatter = (chart, freq) => this.highstockHelper.xAxisLabelFormatter(chart, freq);
     const xAxisExtremes = this.xAxisExtremes;
     const logo = this.logo;

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -32,7 +32,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
   @Input() start;
   @Input() end;
   @Input() indexChecked;
-  @Output() tableExtremes = new EventEmitter(true);
+  @Output() xAxisExtremes = new EventEmitter(true);
   @Output() updateUrl = new EventEmitter<any>();
   Highcharts = Highcharts;
   chartConstructor = 'stockChart';
@@ -343,11 +343,11 @@ export class AnalyzerHighstockComponent implements OnChanges {
     const startDate = this.start || null;
     const endDate = this.end || null;
     const xAxisFormatter = (chart, freq) => this.highstockHelper.xAxisLabelFormatter(chart, freq);
-    const tableExtremes = this.tableExtremes;
+    const xAxisExtremes = this.xAxisExtremes;
     const logo = this.logo;
     const highestFreq = this.analyzerService.getHighestFrequency(this.series).freq;
     const buttons = this.formatChartButtons(this.portalSettings.highstock.buttons);
-    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, tableExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, tableExtremes);
+    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, dates, xAxisExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, dates, xAxisExtremes);
     this.chartOptions.accessibility.description = `${portal}\n${portalLink}`;
     this.chartOptions.series = series.map((s, index) => {
       return {
@@ -489,7 +489,7 @@ export class AnalyzerHighstockComponent implements OnChanges {
       events: {
         setExtremes: function(e) {
           if (e.trigger === 'rangeSelectorButton') {
-            rangeSelectorSetExtremes(e.min, e.max, highestFreq, tableExtremes);
+            rangeSelectorSetExtremes(e.min, e.max, highestFreq, [], xAxisExtremes);
           }
         },
       },

--- a/projects/tools/src/lib/analyzer-table/analyzer-table.component.html
+++ b/projects/tools/src/lib/analyzer-table/analyzer-table.component.html
@@ -18,11 +18,11 @@
   </button>
   <ag-grid-angular style="width: 100%;" class="ag-theme-balham" [rowData]="rows" [columnDefs]="columnDefs" domLayout="autoHeight"
     [frameworkComponents]="frameworkComponents" [gridOptions]="gridOptions" [enableRtl]="true" [suppressDragLeaveHidesColumns]="true"
-    (gridReady)="onGridReady($event)" [singleClickEdit]="true">
+    (gridReady)="onGridReady($event, 'data')" [singleClickEdit]="true">
   </ag-grid-angular>
   <p class="stat-note">*Scroll to the right for additional statistics</p>
   <ag-grid-angular style="width: 100%;" class="ag-theme-balham summary-table" [rowData]="summaryRows" [columnDefs]="summaryColumns" domLayout="autoHeight"
-    [gridOptions]="statGridOptions" [frameworkComponents]="frameworkComponents" [singleClickEdit]="true">
+    [gridOptions]="statGridOptions" [frameworkComponents]="frameworkComponents" [singleClickEdit]="true" (gridReady)="onGridReady($event, 'summary')">
   </ag-grid-angular>
 </ng-template>
 <p *ngIf="missingSummaryStat" class="stat-warning">

--- a/projects/tools/src/lib/analyzer-table/analyzer-table.component.ts
+++ b/projects/tools/src/lib/analyzer-table/analyzer-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit, OnChanges, OnDestroy, Input, Output, EventEmitter, ChangeDetectionStrategy, SimpleChanges } from '@angular/core';
+import { Component, Inject, OnInit, OnChanges, OnDestroy, Input, Output, EventEmitter, SimpleChanges } from '@angular/core';
 import { AnalyzerService } from '../analyzer.service';
 import { SeriesHelperService } from '../series-helper.service';
 import { HelperService } from '../helper.service';
@@ -13,7 +13,6 @@ import { GridOptions } from 'ag-grid-community';
   selector: 'lib-analyzer-table',
   templateUrl: './analyzer-table.component.html',
   styleUrls: ['./analyzer-table.component.scss'],
-  //changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
   @Input() series;

--- a/projects/tools/src/lib/analyzer.service.ts
+++ b/projects/tools/src/lib/analyzer.service.ts
@@ -464,7 +464,10 @@ export class AnalyzerService {
       });
     });
     allDates = allDates.sort(this.dateComparison);
-    if (start && end) { allDates = allDates.filter(date => date.date >= start && date.date <= end); }
+    if (start && end) {
+      allDates = allDates.filter(date => date.date >= start && date.date <= end);
+    }
+    console.log('allDates', allDates)
     return allDates;
   }
 

--- a/projects/tools/src/lib/analyzer/analyzer.component.html
+++ b/projects/tools/src/lib/analyzer/analyzer.component.html
@@ -88,8 +88,7 @@
             [analyzerView]="true" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
           </lib-category-charts>
           <lib-analyzer-highstock *ngIf="displayCompare && data.analyzerSeries.length" [portalSettings]="portalSettings"
-            [series]="data.analyzerSeries" [dates]="data.sliderDates" [start]="selectedDateRange.startDate"
-            [end]="selectedDateRange.endDate" [indexChecked]="indexSeries" (tableExtremes)="changeRange($event)"
+            [series]="data.analyzerSeries" [dates]="data.sliderDates" [indexChecked]="indexSeries" (tableExtremes)="changeRange($event)"
             (xAxisExtremes)="changeRange($event)">
           </lib-analyzer-highstock>
           <lib-analyzer-table *ngIf="data.analyzerSeries.length" [dates]="data.sliderDates" [yoyChecked]="tableYoy"

--- a/projects/tools/src/lib/analyzer/analyzer.component.html
+++ b/projects/tools/src/lib/analyzer/analyzer.component.html
@@ -73,8 +73,8 @@
             [disabled]="!data.displayFreqSelector">Index
         </label>
         <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-          [dates]="data.sliderDates" [dateFrom]="data.minDate" [dateTo]="data.maxDate"
-          [freq]="data.analyzerFrequency.freq" (updateRange)="changeRange($event)"></lib-date-slider>
+          [dates]="data.sliderDates" [routeStart]="routeStart" [routeEnd]="routeEnd" [freq]="data.analyzerFrequency.freq"
+          (updateRange)="changeRange($event)"></lib-date-slider>
         <button type="button" class="btn btn-sm btn-outline-danger rm-analyzer-series-btn"
           (click)="removeAllAnalyzerSeries()">
           Remove All Series
@@ -88,7 +88,7 @@
             [analyzerView]="true" [chartStart]="data.minDate" [chartEnd]="data.maxDate" [routeStart]="data.minDate"
             [routeEnd]="data.maxDate" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
           </lib-category-charts> -->
-          <lib-category-charts *ngIf="!displayCompare && data.minDate" [portalSettings]="portalSettings"
+          <lib-category-charts *ngIf="!displayCompare" [portalSettings]="portalSettings"
             [displayedMeasurements]="data.analyzerMeasurements" [dates]="data.sliderDates"
             [freq]="data.analyzerFrequency.freq" [noSeries]="data.noData" [hasSeasonal]="data.hasSeasonal"
             [analyzerView]="true" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
@@ -97,10 +97,10 @@
             [series]="data.analyzerSeries" [start]="data.minDate" [end]="data.maxDate" [indexChecked]="indexSeries"
             (tableExtremes)="changeRange($event)" (updateUrl)="updateUrlLocation()">
           </lib-analyzer-highstock>
-          <lib-analyzer-table *ngIf="data.analyzerSeries.length" [minDate]="data.minDate" [maxDate]="data.maxDate"
-            [yoyChecked]="tableYoy" [ytdChecked]="tableYtd" [c5maChecked]="tableC5ma" [momChecked]="tableMom"
-            [indexChecked]="indexSeries" [series]="data.analyzerSeries" [freq]="data.analyzerFrequency.freq"
-            [indexBaseYear]="data.baseYear" (tableTransform)="checkTransforms($event)">
+          <lib-analyzer-table *ngIf="data.analyzerSeries.length" [dates]="data.sliderDates" [yoyChecked]="tableYoy"
+            [ytdChecked]="tableYtd" [c5maChecked]="tableC5ma" [momChecked]="tableMom" [indexChecked]="indexSeries"
+            [series]="data.analyzerSeries" [freq]="data.analyzerFrequency.freq" [indexBaseYear]="data.baseYear"
+            (tableTransform)="checkTransforms($event)">
           </lib-analyzer-table>
         </ng-template>
       </div>

--- a/projects/tools/src/lib/analyzer/analyzer.component.html
+++ b/projects/tools/src/lib/analyzer/analyzer.component.html
@@ -57,8 +57,8 @@
               [class.bi-bar-chart-fill]="!displayCompare"></i>{{displayCompare ? ' Gallery View' : ' Compare'}}</span>
         </button>
         <lib-share-link *ngIf="data.analyzerSeries.length" [analyzerSeries]="data.analyzerSeries" [view]="'analyzer'"
-          [index]="indexSeries" [yoy]="tableYoy" [ytd]="tableYtd" [c5ma]="tableC5ma" [startDate]="data.minDate"
-          [endDate]="data.maxDate" [yRightSeries]="data.yRightSeries" [yLeftSeries]="data.yLeftSeries"
+          [index]="indexSeries" [yoy]="tableYoy" [ytd]="tableYtd" [c5ma]="tableC5ma" [startDate]="selectedDateRange.startDate"
+          [endDate]="selectedDateRange.endDate" [yRightSeries]="data.yRightSeries" [yLeftSeries]="data.yLeftSeries"
           [leftMin]="data.leftMin" [leftMax]="data.leftMax" [rightMin]="data.rightMin" [rightMax]="data.rightMax"
           [displayCompare]="displayCompare">
         </lib-share-link>
@@ -73,8 +73,8 @@
             [disabled]="!data.displayFreqSelector">Index
         </label>
         <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-          [dates]="data.sliderDates" [routeStart]="routeStart" [routeEnd]="routeEnd" [freq]="data.analyzerFrequency.freq"
-          (updateRange)="changeRange($event)"></lib-date-slider>
+          [dates]="data.sliderDates" [routeStart]="routeStart" [routeEnd]="routeEnd"
+          [freq]="data.analyzerFrequency.freq" (updateRange)="changeRange($event)"></lib-date-slider>
         <button type="button" class="btn btn-sm btn-outline-danger rm-analyzer-series-btn"
           (click)="removeAllAnalyzerSeries()">
           Remove All Series
@@ -82,20 +82,15 @@
       </div>
       <div class="w-100">
         <ng-template ngIf [ngIf]="data.requestComplete">
-          <!-- <lib-category-charts *ngIf="!displayCompare && data.minDate" [portalSettings]="portalSettings"
-            [displayedMeasurements]="data.analyzerMeasurements" [dates]="data.sliderDates"
-            [freq]="data.analyzerFrequency.freq" [noSeries]="data.noData" [hasSeasonal]="data.hasSeasonal"
-            [analyzerView]="true" [chartStart]="data.minDate" [chartEnd]="data.maxDate" [routeStart]="data.minDate"
-            [routeEnd]="data.maxDate" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
-          </lib-category-charts> -->
           <lib-category-charts *ngIf="!displayCompare" [portalSettings]="portalSettings"
             [displayedMeasurements]="data.analyzerMeasurements" [dates]="data.sliderDates"
             [freq]="data.analyzerFrequency.freq" [noSeries]="data.noData" [hasSeasonal]="data.hasSeasonal"
             [analyzerView]="true" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
           </lib-category-charts>
           <lib-analyzer-highstock *ngIf="displayCompare && data.analyzerSeries.length" [portalSettings]="portalSettings"
-            [series]="data.analyzerSeries" [start]="data.minDate" [end]="data.maxDate" [indexChecked]="indexSeries"
-            (tableExtremes)="changeRange($event)" (updateUrl)="updateUrlLocation()">
+            [series]="data.analyzerSeries" [dates]="data.sliderDates" [start]="selectedDateRange.startDate"
+            [end]="selectedDateRange.endDate" [indexChecked]="indexSeries" (tableExtremes)="changeRange($event)"
+            (xAxisExtremes)="changeRange($event)">
           </lib-analyzer-highstock>
           <lib-analyzer-table *ngIf="data.analyzerSeries.length" [dates]="data.sliderDates" [yoyChecked]="tableYoy"
             [ytdChecked]="tableYtd" [c5maChecked]="tableC5ma" [momChecked]="tableMom" [indexChecked]="indexSeries"

--- a/projects/tools/src/lib/analyzer/analyzer.component.html
+++ b/projects/tools/src/lib/analyzer/analyzer.component.html
@@ -82,11 +82,16 @@
       </div>
       <div class="w-100">
         <ng-template ngIf [ngIf]="data.requestComplete">
-          <lib-category-charts *ngIf="!displayCompare && data.minDate" [portalSettings]="portalSettings"
+          <!-- <lib-category-charts *ngIf="!displayCompare && data.minDate" [portalSettings]="portalSettings"
             [displayedMeasurements]="data.analyzerMeasurements" [dates]="data.sliderDates"
             [freq]="data.analyzerFrequency.freq" [noSeries]="data.noData" [hasSeasonal]="data.hasSeasonal"
             [analyzerView]="true" [chartStart]="data.minDate" [chartEnd]="data.maxDate" [routeStart]="data.minDate"
             [routeEnd]="data.maxDate" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
+          </lib-category-charts> -->
+          <lib-category-charts *ngIf="!displayCompare && data.minDate" [portalSettings]="portalSettings"
+            [displayedMeasurements]="data.analyzerMeasurements" [dates]="data.sliderDates"
+            [freq]="data.analyzerFrequency.freq" [noSeries]="data.noData" [hasSeasonal]="data.hasSeasonal"
+            [analyzerView]="true" [indexChecked]="indexSeries" [indexBaseYear]="data.baseYear">
           </lib-category-charts>
           <lib-analyzer-highstock *ngIf="displayCompare && data.analyzerSeries.length" [portalSettings]="portalSettings"
             [series]="data.analyzerSeries" [start]="data.minDate" [end]="data.maxDate" [indexChecked]="indexSeries"

--- a/projects/tools/src/lib/analyzer/analyzer.component.ts
+++ b/projects/tools/src/lib/analyzer/analyzer.component.ts
@@ -35,6 +35,8 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
   urlParams;
   displayHelp: boolean = false;
   displaySelectionNA: boolean = false;
+  routeStart: string;
+  routeEnd: string;
 
   constructor(
     @Inject('environment') private environment,
@@ -61,8 +63,11 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
         if (params[`chartSeries`]) {
           this.analyzerService.storeUrlChartSeries(params[`chartSeries`]);
         }
+        console.log('params', params)
         this.analyzerService.analyzerData.minDate = params['start'] || '';
         this.analyzerService.analyzerData.maxDate = params['end'] || '';
+        this.routeStart = params[`start`] || null;
+        this.routeEnd = params[`end`] || null;
         this.indexSeries = params['index'] || null;
         this.leftMin = params['leftMin'] || null;
         this.leftMax = params['leftMax'] || null;
@@ -186,8 +191,11 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
   }
 
   changeRange(e) {
+    console.log("CHANGE RANGE", e)
     this.analyzerService.analyzerData.minDate = e.seriesStart;
     this.analyzerService.analyzerData.maxDate = e.seriesEnd;
+    this.routeStart = e.startDate;
+    this.routeEnd = e.endDate;
     if (this.analyzerService.analyzerData.indexed) {
       this.analyzerService.updateBaseYear();
     }
@@ -207,8 +215,8 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
       rightMin,
       rightMax
     } = analyzerData;
-    this.queryParams.start = minDate;
-    this.queryParams.end = maxDate;
+    this.queryParams.start = this.routeStart;
+    this.queryParams.end = this.routeEnd;
     this.queryParams.analyzerSeries = analyzerSeries.map(s => s.id).join('-');
     this.queryParams.chartSeries = analyzerSeries.filter(s => s.visible).map(s => s.id).join('-') || null;
     this.queryParams.yright = yRightSeries.length ? yRightSeries.join('-') : null;
@@ -217,6 +225,7 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
     this.queryParams.leftMax = leftMax ? leftMax : null;
     this.queryParams.rightMin = rightMin ? rightMin : null;
     this.queryParams.rightMax = rightMax ? rightMax : null;
+    console.log('QUERY PARAMS', this.queryParams)
     const url = this.router.createUrlTree([], {
       relativeTo: this.route, queryParams: this.queryParams
     }).toString();

--- a/projects/tools/src/lib/analyzer/analyzer.component.ts
+++ b/projects/tools/src/lib/analyzer/analyzer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, OnDestroy } from '@angular/core';
+import { Component, OnInit, Inject, OnDestroy, ChangeDetectorRef, AfterContentChecked } from '@angular/core';
 import { Location } from '@angular/common';
 import { AnalyzerService } from '../analyzer.service';
 import { DateRange } from '../tools.models';
@@ -13,7 +13,7 @@ import { HelperService } from '../helper.service';
   templateUrl: './analyzer.component.html',
   styleUrls: ['./analyzer.component.scss']
 })
-export class AnalyzerComponent implements OnInit, OnDestroy {
+export class AnalyzerComponent implements OnInit, OnDestroy, AfterContentChecked {
   portalSettings;
   tableYoy: boolean;
   tableYtd: boolean;
@@ -50,6 +50,7 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private apiService: ApiService,
     private router: Router,
+    private cdRef: ChangeDetectorRef,
     private location: Location,
     private helperService: HelperService
   ) {
@@ -107,6 +108,10 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
     }
     this.updateAnalyzer(this.analyzerSeries);
     this.portalSettings = this.dataPortalSettingsServ.dataPortalSettings[this.portal.universe];
+  }
+
+  ngAfterContentChecked() {
+    this.cdRef.detectChanges();
   }
 
   evalParamAsTrue = (param: string) => param === 'true';
@@ -198,8 +203,6 @@ export class AnalyzerComponent implements OnInit, OnDestroy {
   }
 
   changeRange(e) {
-    //this.analyzerService.analyzerData.minDate = e.seriesStart;
-    //this.analyzerService.analyzerData.maxDate = e.seriesEnd;
     this.routeStart = e.startDate;
     this.routeEnd = e.endDate;
     if (this.analyzerService.analyzerData.indexed) {

--- a/projects/tools/src/lib/category-charts/category-charts.component.html
+++ b/projects/tools/src/lib/category-charts/category-charts.component.html
@@ -6,8 +6,7 @@
 				<a href="#" [routerLink]="['/series']" [queryParams]="{id: series.id, sa: series.saParam}"
 					queryParamsHandling='merge' *ngIf="series.id && series.display">
 					<lib-highchart [minValue]="minValue" [maxValue]="maxValue" [portalSettings]="portalSettings"
-						[chartStart]="selectedStart" [chartEnd]="selectedEnd" [seriesData]="series" [indexChecked]="indexChecked"
-						[baseYear]="selectedStart">
+						[seriesData]="series" [indexChecked]="indexChecked" [baseYear]="selectedStart">
 					</lib-highchart>
 				</a>
 				<a *ngIf="series.displaySeasonalMessage">

--- a/projects/tools/src/lib/category-charts/category-charts.component.html
+++ b/projects/tools/src/lib/category-charts/category-charts.component.html
@@ -7,7 +7,7 @@
 					queryParamsHandling='merge' *ngIf="series.id && series.display">
 					<lib-highchart [minValue]="minValue" [maxValue]="maxValue" [portalSettings]="portalSettings"
 						[chartStart]="selectedStart" [chartEnd]="selectedEnd" [seriesData]="series" [indexChecked]="indexChecked"
-						[baseYear]="indexBaseYear">
+						[baseYear]="selectedStart">
 					</lib-highchart>
 				</a>
 				<a *ngIf="series.displaySeasonalMessage">

--- a/projects/tools/src/lib/category-charts/category-charts.component.html
+++ b/projects/tools/src/lib/category-charts/category-charts.component.html
@@ -6,7 +6,7 @@
 				<a href="#" [routerLink]="['/series']" [queryParams]="{id: series.id, sa: series.saParam}"
 					queryParamsHandling='merge' *ngIf="series.id && series.display">
 					<lib-highchart [minValue]="minValue" [maxValue]="maxValue" [portalSettings]="portalSettings"
-						[chartStart]="chartStart" [chartEnd]="chartEnd" [seriesData]="series" [indexChecked]="indexChecked"
+						[chartStart]="selectedStart" [chartEnd]="selectedEnd" [seriesData]="series" [indexChecked]="indexChecked"
 						[baseYear]="indexBaseYear">
 					</lib-highchart>
 				</a>

--- a/projects/tools/src/lib/category-charts/category-charts.component.ts
+++ b/projects/tools/src/lib/category-charts/category-charts.component.ts
@@ -18,14 +18,14 @@ export class CategoryChartsComponent implements OnChanges {
   @Input() noSeries: boolean;
   @Input() showSeasonal: boolean;
   @Input() hasSeasonal: boolean;
-  @Input() chartStart: string;
-  @Input() chartEnd: string;
+  //@Input() chartStart: string;
+  //@Input() chartEnd: string;
   @Input() dates: Array<{date: string, tableDate: string}>;
   @Input() analyzerView: boolean;
   @Input() indexChecked: boolean;
   @Input() indexBaseYear: string;
-  @Input() routeStart;
-  @Input() routeEnd;
+  //@Input() routeStart;
+  //@Input() routeEnd;
   @Input() dateRange;
   @Output() updateURLFragment = new EventEmitter();
   minValue: number;
@@ -33,20 +33,19 @@ export class CategoryChartsComponent implements OnChanges {
   noSeriesToDisplay: boolean;
   dateRangeSubscription: Subscription;
   selectedDateRange;
+  selectedStart;
+  selectedEnd;
 
   constructor(
     @Inject('defaultRange') private defaultRange,
     private helperService: HelperService,
     private analyzerService: AnalyzerService,
   ) {
-    console.log('TEST')
     this.dateRangeSubscription = helperService.currentDateRange.subscribe((dateRange) => {
-      console.log('category charts date range', dateRange)
-
       this.selectedDateRange = dateRange;
-      this.chartStart = dateRange.startDate;
-      this.chartEnd = dateRange.endDate;
-    })
+      this.selectedStart = dateRange.startDate;
+      this.selectedEnd = dateRange.endDate;
+    });
   }
 
   ngOnChanges() {
@@ -55,21 +54,15 @@ export class CategoryChartsComponent implements OnChanges {
         this.helperService.toggleSeriesDisplay(this.hasSeasonal, this.showSeasonal, this.displayedMeasurements[measurement], this.analyzerView);
         this.isSeriesInAnalyzer(this.displayedMeasurements[measurement]);
       });
-      const { seriesStart, seriesEnd } = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange);
-      //this.chartStart = this.dates[seriesStart].date;
-      //this.chartEnd = this.dates[seriesEnd].date;
     }
     this.noSeriesToDisplay = this.helperService.checkIfSeriesAvailable(this.noSeries, this.displayedMeasurements);
     // If setYAxes, chart view should display all charts' (level) yAxis with the same range
     // Allow y-axes to vary for search results
     if (this.portalSettings.highcharts.setYAxes) {
-      const defaultStartEnd = this.defaultRange.find(ranges => ranges.freq === this.freq);
-      const start = this.chartStart || Date.parse(defaultStartEnd.start);
-      const end = this.chartEnd || Date.parse(defaultStartEnd.end);
       if (this.findMinMax) {
         // Find minimum and maximum values out of all series within a sublist; Use values to set min/max of yAxis
-        this.minValue = this.findMin(this.displayedMeasurements, start, end);
-        this.maxValue = this.findMax(this.displayedMeasurements, start, end);
+        this.minValue = this.findMin(this.displayedMeasurements, this.selectedStart, this.selectedEnd);
+        this.maxValue = this.findMax(this.displayedMeasurements, this.selectedStart, this.selectedEnd);
       }
     }
   }

--- a/projects/tools/src/lib/category-charts/category-charts.component.ts
+++ b/projects/tools/src/lib/category-charts/category-charts.component.ts
@@ -1,5 +1,6 @@
 import { KeyValue } from '@angular/common';
 import { Component, Input, OnChanges, Inject, Output, EventEmitter } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { AnalyzerService } from '../analyzer.service';
 import { HelperService } from '../helper.service';
 
@@ -25,16 +26,28 @@ export class CategoryChartsComponent implements OnChanges {
   @Input() indexBaseYear: string;
   @Input() routeStart;
   @Input() routeEnd;
+  @Input() dateRange;
   @Output() updateURLFragment = new EventEmitter();
   minValue: number;
   maxValue: number;
   noSeriesToDisplay: boolean;
+  dateRangeSubscription: Subscription;
+  selectedDateRange;
 
   constructor(
     @Inject('defaultRange') private defaultRange,
     private helperService: HelperService,
     private analyzerService: AnalyzerService,
-  ) { }
+  ) {
+    console.log('TEST')
+    this.dateRangeSubscription = helperService.currentDateRange.subscribe((dateRange) => {
+      console.log('category charts date range', dateRange)
+
+      this.selectedDateRange = dateRange;
+      this.chartStart = dateRange.startDate;
+      this.chartEnd = dateRange.endDate;
+    })
+  }
 
   ngOnChanges() {
     if (this.displayedMeasurements) {
@@ -43,8 +56,8 @@ export class CategoryChartsComponent implements OnChanges {
         this.isSeriesInAnalyzer(this.displayedMeasurements[measurement]);
       });
       const { seriesStart, seriesEnd } = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange);
-      this.chartStart = this.dates[seriesStart].date;
-      this.chartEnd = this.dates[seriesEnd].date;
+      //this.chartStart = this.dates[seriesStart].date;
+      //this.chartEnd = this.dates[seriesEnd].date;
     }
     this.noSeriesToDisplay = this.helperService.checkIfSeriesAvailable(this.noSeries, this.displayedMeasurements);
     // If setYAxes, chart view should display all charts' (level) yAxis with the same range

--- a/projects/tools/src/lib/category-charts/category-charts.component.ts
+++ b/projects/tools/src/lib/category-charts/category-charts.component.ts
@@ -18,14 +18,10 @@ export class CategoryChartsComponent implements OnChanges {
   @Input() noSeries: boolean;
   @Input() showSeasonal: boolean;
   @Input() hasSeasonal: boolean;
-  //@Input() chartStart: string;
-  //@Input() chartEnd: string;
   @Input() dates: Array<{date: string, tableDate: string}>;
   @Input() analyzerView: boolean;
   @Input() indexChecked: boolean;
   @Input() indexBaseYear: string;
-  //@Input() routeStart;
-  //@Input() routeEnd;
   @Input() dateRange;
   @Output() updateURLFragment = new EventEmitter();
   minValue: number;
@@ -124,16 +120,16 @@ export class CategoryChartsComponent implements OnChanges {
 
   removeFromAnalyzer(series) {
     series.analyze = false;
-    this.analyzerService.removeFromAnalyzer(series.id);
+    this.analyzerService.removeFromAnalyzer(series.id, this.selectedDateRange.startDate);
   }
 
   addCompare(series) {
     series.visible = true;
-    this.analyzerService.makeCompareSeriesVisible(series);
+    this.analyzerService.makeCompareSeriesVisible(series, this.selectedDateRange.startDate);
   }
 
   removeCompare(series) {
     series.visible = false;
-    this.analyzerService.removeFromComparisonChart(series.id);
+    this.analyzerService.removeFromComparisonChart(series.id, this.selectedDateRange.startDate);
   }
 }

--- a/projects/tools/src/lib/category-charts/category-charts.component.ts
+++ b/projects/tools/src/lib/category-charts/category-charts.component.ts
@@ -22,7 +22,6 @@ export class CategoryChartsComponent implements OnChanges {
   @Input() analyzerView: boolean;
   @Input() indexChecked: boolean;
   @Input() indexBaseYear: string;
-  @Input() dateRange;
   @Output() updateURLFragment = new EventEmitter();
   minValue: number;
   maxValue: number;

--- a/projects/tools/src/lib/category-helper.service.ts
+++ b/projects/tools/src/lib/category-helper.service.ts
@@ -3,7 +3,7 @@ import { of as observableOf, Observable, forkJoin, of } from 'rxjs';
 import { Injectable, Inject } from '@angular/core';
 import { ApiService } from './api.service';
 import { HelperService } from './helper.service';
-import { CategoryData, DateWrapper, Geography, Frequency } from './tools.models';
+import { CategoryData, DateWrapper, Geography, Frequency, DateRange } from './tools.models';
 import { switchMap, tap } from 'rxjs/operators';
 import { DataPortalSettingsService } from './data-portal-settings.service';
 
@@ -27,6 +27,7 @@ export class CategoryHelperService {
   // Called on page load
   // Gets data sublists available for a selected category
   initContent = (catId: any, noCache: boolean, routeParams: any): Observable<any> => {
+    console.log('catId', catId)
     const cacheId = this.helperService.setCacheId(catId, routeParams);
     if (this.categoryData.hasOwnProperty(cacheId)) {
       this.updateSelectors(this.categoryData[cacheId], this.portal.universe);
@@ -37,6 +38,7 @@ export class CategoryHelperService {
         this.getCategoryData(this.categoryData[cacheId], noCache, catId, routeParams) :
         this.initSearch(this.categoryData[cacheId], noCache, catId);
     }
+    console.log(this.categoryData)
     return observableOf([this.categoryData[cacheId]]);
   }
 
@@ -91,7 +93,12 @@ export class CategoryHelperService {
   }
 
   updateSelectors(cachedCategoryData: any, portal: string) {
-    const { updateCurrentFrequency, updateCurrentForecast, updateCurrentGeography } = this.helperService;
+    const {
+      updateCurrentFrequency,
+      updateCurrentForecast,
+      updateCurrentGeography,
+      updateCurrentDateRange
+    } = this.helperService;
     if (portal !== 'nta') {
       updateCurrentGeography(cachedCategoryData.currentGeo);
     }
@@ -99,6 +106,9 @@ export class CategoryHelperService {
       updateCurrentForecast(cachedCategoryData.currentForecast);
     }
     updateCurrentFrequency(cachedCategoryData.currentFreq);
+    updateCurrentDateRange({
+      startDate: '', endDate: '', endOfSample: false
+    });
   }
 
   setNoCategoryCata(cachedCategoryData: any) {

--- a/projects/tools/src/lib/category-helper.service.ts
+++ b/projects/tools/src/lib/category-helper.service.ts
@@ -97,7 +97,6 @@ export class CategoryHelperService {
       updateCurrentFrequency,
       updateCurrentForecast,
       updateCurrentGeography,
-      updateCurrentDateRange
     } = this.helperService;
     if (portal !== 'nta') {
       updateCurrentGeography(cachedCategoryData.currentGeo);
@@ -106,9 +105,6 @@ export class CategoryHelperService {
       updateCurrentForecast(cachedCategoryData.currentForecast);
     }
     updateCurrentFrequency(cachedCategoryData.currentFreq);
-    updateCurrentDateRange({
-      startDate: '', endDate: '', endOfSample: false
-    });
   }
 
   setNoCategoryCata(cachedCategoryData: any) {

--- a/projects/tools/src/lib/category-helper.service.ts
+++ b/projects/tools/src/lib/category-helper.service.ts
@@ -27,7 +27,6 @@ export class CategoryHelperService {
   // Called on page load
   // Gets data sublists available for a selected category
   initContent = (catId: any, noCache: boolean, routeParams: any): Observable<any> => {
-    console.log('catId', catId)
     const cacheId = this.helperService.setCacheId(catId, routeParams);
     if (this.categoryData.hasOwnProperty(cacheId)) {
       this.updateSelectors(this.categoryData[cacheId], this.portal.universe);
@@ -38,7 +37,6 @@ export class CategoryHelperService {
         this.getCategoryData(this.categoryData[cacheId], noCache, catId, routeParams) :
         this.initSearch(this.categoryData[cacheId], noCache, catId);
     }
-    console.log(this.categoryData)
     return observableOf([this.categoryData[cacheId]]);
   }
 

--- a/projects/tools/src/lib/category-table-render/category-table-render.component.ts
+++ b/projects/tools/src/lib/category-table-render/category-table-render.component.ts
@@ -10,14 +10,19 @@ import { AnalyzerService } from '../analyzer.service';
 })
 export class CategoryTableRenderComponent implements ICellRendererAngularComp {
   public params: any;
+  startDate: string;
 
   constructor(
     private tableHelper: TableHelperService,
-    private analyzerService: AnalyzerService
-  ) {  }
+    private analyzerService: AnalyzerService,
+  ) { 
+    
+  }
 
   agInit(params: any): void {
     this.params = params;
+    const displayedColumns = params.columnApi.getAllDisplayedColumns();
+    this.startDate = displayedColumns[displayedColumns.length - 2].colDef.field;
   }
 
   refresh(): boolean {
@@ -35,6 +40,6 @@ export class CategoryTableRenderComponent implements ICellRendererAngularComp {
 
   removeFromAnalyzer(series) {
     series.analyze = false;
-    this.analyzerService.removeFromAnalyzer(series.id);
+    this.analyzerService.removeFromAnalyzer(series.id, this.startDate);
   }
 }

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.ts
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.ts
@@ -23,8 +23,6 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
   @Input() ytdActive;
   @Input() c5maActive;
   @Input() params;
-  //@Input() tableStart;
-  //@Input() tableEnd;
   @Input() portalSettings;
   @Input() showSeasonal: boolean;
   @Input() hasSeasonal;

--- a/projects/tools/src/lib/date-slider/date-slider.component.ts
+++ b/projects/tools/src/lib/date-slider/date-slider.component.ts
@@ -28,8 +28,6 @@ export class DateSliderComponent implements OnChanges {
   minDateValue;
   maxDateValue;
   value;
-  //routeStart: string;
-  // routeEnd: string;
   calendarStartDateFormat: string;
   calendarEndDateFormat: string;
   calendarView: string;
@@ -50,36 +48,47 @@ export class DateSliderComponent implements OnChanges {
   ) {}
 
   ngOnChanges() {
-    console.log('ROUTE START', this.routeStart)
-    console.log('ROUTE END', this.routeEnd);
     this.sliderDates = this.dates.map(d => d.date);
     if (this.routeStart && this.routeEnd) {
-      const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange);
+      this.updateDateRange(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange, false);
+      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange);
       const { seriesStart: start, seriesEnd: end } = defaultRanges;
       this.start = start;
       this.end = end;
       this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, false, this.dates);
-      this.sliderSelectedRange = [start, end];
+      this.sliderSelectedRange = [start, end]; */
     } else if (this.routeStart && !this.routeEnd) {
-      const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, '', this.freq, this.defaultRange);
+      this.updateDateRange(this.dates, this.routeStart, '', this.freq, this.defaultRange, false);
+
+      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, '', this.freq, this.defaultRange);
       const { seriesStart: start, seriesEnd: end } = defaultRanges;
       this.start = start;
       this.end = end;
       this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, false, this.dates);
-      this.sliderSelectedRange = [start, end];
+      this.sliderSelectedRange = [start, end]; */
     } else {
-      const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, '', '', this.freq, this.defaultRange);
+      this.updateDateRange(this.dates, '', '', this.freq, this.defaultRange, true);
+
+      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, '', '', this.freq, this.defaultRange);
       const { seriesStart: start, seriesEnd: end } = defaultRanges;
       this.start = start;
       this.end = end;
       this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, true, this.dates);
-      this.sliderSelectedRange = [start, end];
+      this.sliderSelectedRange = [start, end]; */
     }
-    
     this.setDatePickerInputs();
   }
 
-  updateDateRange(start: string, end: string) {
+  updateDateRange(dates: Array<any>, start: string, end: string, freq: string, defaultRange, useDefaultRange: boolean) {
+    const defaultRanges = this.helperService.getSeriesStartAndEnd(dates, start, end, freq, defaultRange);
+    const { seriesStart, seriesEnd } = defaultRanges;
+    this.start = seriesStart;
+    this.end = seriesEnd;
+    this.helperService.setCurrentDateRange(dates[seriesStart].date, dates[seriesEnd].date, useDefaultRange, dates);
+    this.sliderSelectedRange = [seriesStart, seriesEnd];
+  }
+
+  /* updateDateRange(start: string, end: string) {
     const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, start, end, this.freq, this.defaultRange);
     this.start = defaultRanges.seriesStart;
     this.end = defaultRanges.seriesEnd;
@@ -110,7 +119,7 @@ export class DateSliderComponent implements OnChanges {
     }
     this.sliderSelectedRange = [this.start, this.end];
     this.setDatePickerInputs();
-  }
+  } */
 
   setDatePickerInputs() {
     // Date picker inputs

--- a/projects/tools/src/lib/date-slider/date-slider.component.ts
+++ b/projects/tools/src/lib/date-slider/date-slider.component.ts
@@ -52,7 +52,8 @@ export class DateSliderComponent implements OnChanges {
     if (this.routeStart && this.routeEnd) {
       this.updateDateRange(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange, false);
     } else if (this.routeStart && !this.routeEnd) {
-      this.updateDateRange(this.dates, this.routeStart, '', this.freq, this.defaultRange, false);
+      // if start date specified without an end date, display until end of availble data
+      this.updateDateRange(this.dates, this.routeStart, this.dates[this.dates.length - 1].date, this.freq, this.defaultRange, false);
     } else {
       this.updateDateRange(this.dates, '', '', this.freq, this.defaultRange, true);
     }

--- a/projects/tools/src/lib/date-slider/date-slider.component.ts
+++ b/projects/tools/src/lib/date-slider/date-slider.component.ts
@@ -51,30 +51,10 @@ export class DateSliderComponent implements OnChanges {
     this.sliderDates = this.dates.map(d => d.date);
     if (this.routeStart && this.routeEnd) {
       this.updateDateRange(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange, false);
-      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, this.routeEnd, this.freq, this.defaultRange);
-      const { seriesStart: start, seriesEnd: end } = defaultRanges;
-      this.start = start;
-      this.end = end;
-      this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, false, this.dates);
-      this.sliderSelectedRange = [start, end]; */
     } else if (this.routeStart && !this.routeEnd) {
       this.updateDateRange(this.dates, this.routeStart, '', this.freq, this.defaultRange, false);
-
-      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, this.routeStart, '', this.freq, this.defaultRange);
-      const { seriesStart: start, seriesEnd: end } = defaultRanges;
-      this.start = start;
-      this.end = end;
-      this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, false, this.dates);
-      this.sliderSelectedRange = [start, end]; */
     } else {
       this.updateDateRange(this.dates, '', '', this.freq, this.defaultRange, true);
-
-      /* const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, '', '', this.freq, this.defaultRange);
-      const { seriesStart: start, seriesEnd: end } = defaultRanges;
-      this.start = start;
-      this.end = end;
-      this.helperService.setCurrentDateRange(this.dates[start].date, this.dates[end].date, true, this.dates);
-      this.sliderSelectedRange = [start, end]; */
     }
     this.setDatePickerInputs();
   }
@@ -87,39 +67,6 @@ export class DateSliderComponent implements OnChanges {
     this.helperService.setCurrentDateRange(dates[seriesStart].date, dates[seriesEnd].date, useDefaultRange, dates);
     this.sliderSelectedRange = [seriesStart, seriesEnd];
   }
-
-  /* updateDateRange(start: string, end: string) {
-    const defaultRanges = this.helperService.getSeriesStartAndEnd(this.dates, start, end, this.freq, this.defaultRange);
-    this.start = defaultRanges.seriesStart;
-    this.end = defaultRanges.seriesEnd;
-    if (start) {
-      this.helperService.updateCurrentDateRange({
-        ...this.selectedDateRange,
-        startDate: this.dates[this.start].date,
-        useDefaultRange: false,
-        endOfSample: this.end === this.dates.length - 1
-      });
-    }
-    if (end) {
-      this.helperService.updateCurrentDateRange({
-        ...this.selectedDateRange,
-        endDate: this.dates[this.end].date,
-        useDefaultRange: false,
-        endOfSample: this.end === this.dates.length - 1
-      });
-    }
-    if (!start && !end) {
-      this.helperService.updateCurrentDateRange({
-        ...this.selectedDateRange,
-        startDate: this.dates[this.start].date,
-        endDate: this.dates[this.end].date,
-        useDefaultRange: false,
-        endOfSample: this.end === this.dates.length - 1
-      });
-    }
-    this.sliderSelectedRange = [this.start, this.end];
-    this.setDatePickerInputs();
-  } */
 
   setDatePickerInputs() {
     // Date picker inputs
@@ -340,9 +287,5 @@ export class DateSliderComponent implements OnChanges {
       endOfSample
     });
     this.updateRange.emit({ startDate: from, endDate: to, useDefaultRange: false, endOfSample });
-    /* const seriesStart = from;
-    const seriesEnd = to;
-    this.helperService.updateCurrentDateRange({ startDate: seriesStart, endDate: seriesEnd, endOfSample });
-    this.updateRange.emit({ seriesStart, seriesEnd, endOfSample }); */
   }
 }

--- a/projects/tools/src/lib/embed-graph/embed-graph.component.html
+++ b/projects/tools/src/lib/embed-graph/embed-graph.component.html
@@ -1,11 +1,17 @@
 <ng-template ngFor let-data [ngForOf]="seriesData | async">
-  <lib-highstock *ngIf="!data.noData" [portalSettings]="portalSettings" [chartData]="data.chartData"
-    [seriesDetail]="data.seriesDetail" [showTitle]="true" [start]="startDate" [end]="endDate"></lib-highstock>
+  <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
+    [dates]="data.sliderDates" [freq]="data.seriesDetail.frequencyShort" [routeStart]="startDate"
+    [routeEnd]="endDate"></lib-date-slider>
+  <lib-highstock *ngIf="!data.noData && data.requestComplete" [portalSettings]="portalSettings"
+    [chartData]="data.chartData" [seriesDetail]="data.seriesDetail" [showTitle]="true"></lib-highstock>
 </ng-template>
 <ng-template ngFor let-data [ngForOf]="analyzerData | async">
-  <div>
+  <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
+    [dates]="data.sliderDates" [routeStart]="startDate" [routeEnd]="endDate"
+    [freq]="data.analyzerFrequency.freq"></lib-date-slider>
+  <div class="analyzer-view">
     <lib-analyzer-highstock *ngIf="data.analyzerSeries.length" [portalSettings]="portalSettings"
-      [series]="data.analyzerSeries" [start]="startDate" [end]="endDate" [indexChecked]="indexSeries">
+      [series]="data.analyzerSeries" [indexChecked]="indexSeries">
     </lib-analyzer-highstock>
   </div>
 </ng-template>

--- a/projects/tools/src/lib/embed-graph/embed-graph.component.ts
+++ b/projects/tools/src/lib/embed-graph/embed-graph.component.ts
@@ -83,7 +83,7 @@ export class EmbedGraphComponent implements OnInit, OnDestroy {
       this.seriesData = this.seriesHelper.getSeriesData(this.seriesId, true);
     }
     if (this.analyzerIds) {
-      this.analyzerData = this.analyzerService.getAnalyzerData(this.analyzerIds, true);
+      this.analyzerData = this.analyzerService.getAnalyzerData(this.analyzerIds, this.startDate, true);
     }
   }
 

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -1,18 +1,20 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { Frequency, Geography, DateWrapper } from './tools.models';
+import { BehaviorSubject } from 'rxjs';
+import { Frequency, Geography, DateWrapper, DateRange } from './tools.models';
 
 @Injectable({
   providedIn: 'root'
 })
 export class HelperService {
-  private categoryData = new Subject();
+  // private categoryData = new Subject();
   currentFreqChange: BehaviorSubject<any> = new BehaviorSubject(null);
   currentFreq = this.currentFreqChange.asObservable();
   currentGeoChange: BehaviorSubject<any> = new BehaviorSubject(null);
   currentGeo = this.currentGeoChange.asObservable();
   currentFcChange: BehaviorSubject<any> = new BehaviorSubject(null);
   currentFc = this.currentFcChange.asObservable();
+  currentDateRangeChange: BehaviorSubject<any> = new BehaviorSubject(null);
+  currentDateRange = this.currentDateRangeChange.asObservable();
 
 
   constructor() { }
@@ -38,6 +40,12 @@ export class HelperService {
   updateCurrentGeography = (newGeo: Geography) => {
     this.currentGeoChange.next(newGeo);
     return newGeo;
+  }
+
+  updateCurrentDateRange = (newDateRange: DateRange) => {
+    console.log('newDateRange', newDateRange)
+    this.currentDateRangeChange.next(newDateRange);
+    return newDateRange;
   }
 
   getIdParam = (id: any) => {

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -13,7 +13,7 @@ export class HelperService {
   currentGeo = this.currentGeoChange.asObservable();
   currentFcChange: BehaviorSubject<any> = new BehaviorSubject(null);
   currentFc = this.currentFcChange.asObservable();
-  currentDateRangeChange: BehaviorSubject<any> = new BehaviorSubject(null);
+  currentDateRangeChange: BehaviorSubject<any> = new BehaviorSubject(<DateRange>{});
   currentDateRange = this.currentDateRangeChange.asObservable();
 
 
@@ -22,7 +22,9 @@ export class HelperService {
   setCacheId(category: any, routeParams: any) {
     let id = `category${category}`;
     Object.keys(routeParams).forEach((param) => {
-      id += routeParams[param] ? `${param}${routeParams[param]}` : ``;
+      if (param !== 'routeStart' && param !== 'routeEnd') {
+        id += routeParams[param] ? `${param}${routeParams[param]}` : ``;
+      }
     });
     return id;
   }
@@ -43,7 +45,6 @@ export class HelperService {
   }
 
   updateCurrentDateRange = (newDateRange: DateRange) => {
-    console.log('newDateRange', newDateRange)
     this.currentDateRangeChange.next(newDateRange);
     return newDateRange;
   }

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -49,6 +49,15 @@ export class HelperService {
     return newDateRange;
   }
 
+  setCurrentDateRange = (start: string, end: string, useDefault: boolean, dates: Array<any>) => {
+    this.updateCurrentDateRange({
+      startDate: start,
+      endDate: end,
+      useDefaultRange: useDefault,
+      endOfSample: end === dates[dates.length - 1].date
+    });
+  }
+
   getIdParam = (id: any) => {
     if (id === undefined) {
       return null;

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -1,8 +1,8 @@
-import { Component, Inject, OnChanges, Input } from '@angular/core';
+import { Component, Inject, OnInit, OnChanges, OnDestroy, Input, SimpleChanges } from '@angular/core';
 import { HelperService } from '../helper.service';
 import { AnalyzerService } from '../analyzer.service';
 import * as Highcharts from 'highcharts';
-import { HighchartsObject } from '../tools.models';
+import { DateRange } from '../tools.models';
 import { Subscription } from 'rxjs';
 
 type CustomSeriesOptions = Highcharts.SeriesOptionsType & {endDate: string, _indexed: boolean};
@@ -12,11 +12,9 @@ type CustomSeriesOptions = Highcharts.SeriesOptionsType & {endDate: string, _ind
   templateUrl: './highchart.component.html',
   styleUrls: ['./highchart.component.scss']
 })
-export class HighchartComponent implements OnChanges {
+export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
   @Input() portalSettings;
   @Input() seriesData;
-  @Input() chartStart;
-  @Input() chartEnd;
   @Input() minValue;
   @Input() maxValue;
   @Input() indexChecked;
@@ -27,9 +25,8 @@ export class HighchartComponent implements OnChanges {
   chartOptions: Highcharts.Options = {} //as HighchartsObject;
   updateChart = false;
   dateRangeSubscription: Subscription;
-  selectedDateRange;
-  xAxisStart;
-  xAxisEnd;
+  selectedDateRange: DateRange;
+
   static findLastValue(valueArray, endDate, start) {
     const firstSeriesObs = valueArray[0].x;
     const lastSeriesObs = valueArray[valueArray.length - 1].x;
@@ -52,22 +49,55 @@ export class HighchartComponent implements OnChanges {
     };
   }
 
-  ngOnChanges() {
-    if (this.seriesData === 'No data available') {
-      this.noDataChart(this.seriesData);
-      this.updateChart = true;
-    } else {
-      this.drawChart(this.seriesData, this.portalSettings, this.minValue, this.maxValue, this.chartStart, this.chartEnd);
-      this.updateChart = true;
-    }
-    if (this.chartObject) {
-      this.chartObject.redraw();
+  ngOnInit(): void {
+    this.dateRangeSubscription = this.helperService.currentDateRange.subscribe((dateRange) => {
+      this.selectedDateRange = dateRange;
+      const { startDate, endDate } = dateRange;
+      if (this.seriesData === 'No data available') {
+        this.noDataChart(this.seriesData, `<b>${this.seriesData.displayTitle}</b><br />No Data Available`, '');
+        this.updateChart = true;
+      } else {
+        this.drawChart(this.seriesData, this.portalSettings, this.minValue, this.maxValue, startDate, endDate);
+      }
+      if (this.chartObject) {
+        this.chartObject.redraw();
+      }
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const indexCheckChange = changes['indexChecked'];
+    const baseYearChange = changes['baseYear'];
+    const seriesDataChange = changes['seriesData']; 
+    const maxValueChange = changes['maxValue'];
+    const minValueChange = changes['minValue'];
+    if (
+      (indexCheckChange && !indexCheckChange.firstChange) ||
+      (baseYearChange && !baseYearChange.firstChange) ||
+      (seriesDataChange && !seriesDataChange.firstChange) ||
+      (minValueChange && !minValueChange.firstChange) ||
+      (maxValueChange && !maxValueChange.firstChange)
+    ) {
+      const { startDate, endDate } = this.selectedDateRange;
+      this.drawChart(this.seriesData, this.portalSettings, this.minValue, this.maxValue, startDate, endDate);
+      if (this.chartObject) {
+        this.chartObject.redraw();
+      }
     }
   }
 
-  noDataChart = (seriesData) => {
-    const title = seriesData.displayName;
-    this.chartOptions.title = this.setChartTitle(`<b>${title}</b><br />No Data Available`);
+  drawChart = (seriesData, portalSettings, minValue: number, maxValue: number, startDate: string, endDate: string) => {
+    this.updateChartOptions(seriesData, portalSettings, minValue, maxValue, startDate, endDate);
+    this.updateChart = true;
+  }
+
+  ngOnDestroy(): void {
+    this.dateRangeSubscription.unsubscribe();
+  }
+
+  noDataChart = (seriesData, chartTitle: string, subtitle: string) => {
+    this.chartOptions.title = this.setChartTitle(chartTitle);
+    this.chartOptions.subtitle = this.setSubtitle(subtitle);
     this.chartOptions.exporting = { enabled: false };
     this.chartOptions.legend = { enabled: false };
     this.chartOptions.credits = { enabled: false };
@@ -98,14 +128,22 @@ export class HighchartComponent implements OnChanges {
     return {
       text: title,
       useHTML: true,
-      align: 'left' as Highcharts.AlignValue,
+      align: 'left',
       widthAdjust: 0,
       x: 0,
       y: -5,
       style: {
         margin: 75
       }
-    };
+    } as Highcharts.TitleOptions;
+  }
+
+  setSubtitle = (subtitle: string) => {
+    return {
+      text: subtitle,
+      verticalAlign: 'middle',
+      y: -20
+    } as Highcharts.SubtitleOptions
   }
 
   setYAxis = (min: number, max: number) => {
@@ -169,7 +207,7 @@ export class HighchartComponent implements OnChanges {
     return chartSeries;
   }
 
-  drawChart = (seriesData, portalSettings, min: number, max: number, chartStart, chartEnd) => {
+  updateChartOptions = (seriesData, portalSettings, min: number, max: number, chartStart, chartEnd) => {
     const {
       percent,
       title,
@@ -264,7 +302,7 @@ export class HighchartComponent implements OnChanges {
             checkPointCount(currentFreq, s0, s0.points[lastValue0], this);
           }
           // If no data available for a given date range, display series title and display dates where data is available for a series
-          if (lastValue0 === -1 && lastValue1 === -1) {
+         if (lastValue0 === -1 && lastValue1 === -1) {
             this.setClassName(undefined);
             const categoryDisplayStart = formatDate(Date.parse(start), currentFreq);
             const categoryDisplayEnd = formatDate(Date.parse(end), currentFreq);
@@ -337,8 +375,8 @@ export class HighchartComponent implements OnChanges {
     };
     this.chartOptions.legend = { enabled: false };
     this.chartOptions.credits = { enabled: false };
-    this.chartOptions.xAxis = this.setXAxis(startDate, endDate); //this.setXAxis(this.xAxisStart, this.xAxisEnd)//
-    this.chartOptions.yAxis = this.setYAxis(min, max);
+    this.chartOptions.xAxis = end < chartStart ? this.setXAxis(null, null) : this.setXAxis(startDate, endDate);
+    this.chartOptions.yAxis = end < chartStart ? this.setYAxis(null, null) :  this.setYAxis(min, max);
     this.chartOptions.plotOptions = {
       line: {
         marker: {

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -50,11 +50,6 @@ export class HighchartComponent implements OnChanges {
     this.chartCallback = chart => {
       this.chartObject = chart;
     };
-    this.dateRangeSubscription = helperService.currentDateRange.subscribe((dateRange) => {
-      this.selectedDateRange = dateRange;
-      this.xAxisStart = Date.parse(dateRange.startDate);
-      this.xAxisEnd = Date.parse(dateRange.endDate);
-    })
   }
 
   ngOnChanges() {
@@ -190,6 +185,7 @@ export class HighchartComponent implements OnChanges {
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
     series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], this._analyzerService.analyzerData.baseYear) : series0;
     console.log('HIGHCHARTS chartStart', chartStart)
+    console.log('HIGHCHARTS start', start)
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
     // Check how many non-null points exist in level series
@@ -343,7 +339,7 @@ export class HighchartComponent implements OnChanges {
     };
     this.chartOptions.legend = { enabled: false };
     this.chartOptions.credits = { enabled: false };
-    this.chartOptions.xAxis = this.setXAxis(this.xAxisStart, this.xAxisEnd)//this.setXAxis(startDate, endDate);
+    this.chartOptions.xAxis = this.setXAxis(startDate, endDate); //this.setXAxis(this.xAxisStart, this.xAxisEnd)//
     this.chartOptions.yAxis = this.setYAxis(min, max);
     this.chartOptions.plotOptions = {
       line: {

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -183,7 +183,7 @@ export class HighchartComponent implements OnChanges {
     const { start, end } = gridDisplay;
     const decimals = seriesData.decimals || 1;
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
-    series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], this._analyzerService.analyzerData.baseYear) : series0;
+    series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], chartStart) : series0;
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
     // Check how many non-null points exist in level series

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -184,8 +184,6 @@ export class HighchartComponent implements OnChanges {
     const decimals = seriesData.decimals || 1;
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
     series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], this._analyzerService.analyzerData.baseYear) : series0;
-    console.log('HIGHCHARTS chartStart', chartStart)
-    console.log('HIGHCHARTS start', start)
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
     // Check how many non-null points exist in level series

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -3,6 +3,7 @@ import { HelperService } from '../helper.service';
 import { AnalyzerService } from '../analyzer.service';
 import * as Highcharts from 'highcharts';
 import { HighchartsObject } from '../tools.models';
+import { Subscription } from 'rxjs';
 
 type CustomSeriesOptions = Highcharts.SeriesOptionsType & {endDate: string, _indexed: boolean};
 
@@ -25,7 +26,10 @@ export class HighchartComponent implements OnChanges {
   Highcharts: typeof Highcharts = Highcharts;
   chartOptions: Highcharts.Options = {} //as HighchartsObject;
   updateChart = false;
-
+  dateRangeSubscription: Subscription;
+  selectedDateRange;
+  xAxisStart;
+  xAxisEnd;
   static findLastValue(valueArray, endDate, start) {
     const firstSeriesObs = valueArray[0].x;
     const lastSeriesObs = valueArray[valueArray.length - 1].x;
@@ -46,6 +50,11 @@ export class HighchartComponent implements OnChanges {
     this.chartCallback = chart => {
       this.chartObject = chart;
     };
+    this.dateRangeSubscription = helperService.currentDateRange.subscribe((dateRange) => {
+      this.selectedDateRange = dateRange;
+      this.xAxisStart = Date.parse(dateRange.startDate);
+      this.xAxisEnd = Date.parse(dateRange.endDate);
+    })
   }
 
   ngOnChanges() {
@@ -180,6 +189,7 @@ export class HighchartComponent implements OnChanges {
     const decimals = seriesData.decimals || 1;
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
     series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], this._analyzerService.analyzerData.baseYear) : series0;
+    console.log('HIGHCHARTS chartStart', chartStart)
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
     // Check how many non-null points exist in level series
@@ -333,7 +343,7 @@ export class HighchartComponent implements OnChanges {
     };
     this.chartOptions.legend = { enabled: false };
     this.chartOptions.credits = { enabled: false };
-    this.chartOptions.xAxis = this.setXAxis(startDate, endDate);
+    this.chartOptions.xAxis = this.setXAxis(this.xAxisStart, this.xAxisEnd)//this.setXAxis(startDate, endDate);
     this.chartOptions.yAxis = this.setYAxis(min, max);
     this.chartOptions.plotOptions = {
       line: {

--- a/projects/tools/src/lib/highstock-helper.service.ts
+++ b/projects/tools/src/lib/highstock-helper.service.ts
@@ -72,18 +72,18 @@ export class HighstockHelperService {
     return firstOfMonth[freq] || date;
   }
 
-  rangeSelectorSetExtremesEvent(eventMin, eventMax, frequency: string, tableExtremes: any) {
+  rangeSelectorSetExtremesEvent(eventMin, eventMax, frequency: string, dates: Array<any>, xAxisExtremes: any) {
     const userMin = new Date(eventMin).toISOString().split('T')[0];
     const userMax = new Date(eventMax).toISOString().split('T')[0];
     const selectedMin = this.setDateToFirstOfMonth(frequency, userMin);
     const selectedMax = this.setDateToFirstOfMonth(frequency, userMax);
-    this.helperService.updateCurrentDateRange({
+    this.helperService.setCurrentDateRange(selectedMin, selectedMax, false, dates);
+    xAxisExtremes.emit({
       startDate: selectedMin,
       endDate: selectedMax,
-      endOfSample: false,
-      useDefaultRange: false
+      useDefaultRange: false,
+      endOfSample: selectedMax === dates[dates.length - 1].date
     });
-    tableExtremes.emit({ seriesStart: selectedMin, seriesEnd: selectedMax });
   }
 
   freqInterval = (freq: string) => {

--- a/projects/tools/src/lib/highstock-helper.service.ts
+++ b/projects/tools/src/lib/highstock-helper.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { HelperService } from './helper.service';
 import * as Highcharts from 'highcharts/highstock';
 
 Highcharts.dateFormats['Q'] = (timestamp) => {
@@ -38,28 +39,13 @@ export class HighstockHelperService {
       return `${month} ${day}, ${year}`;
     }
   }
-
-  static rangeSelectorSetExtremesEvent(eventMin, eventMax, frequency: string, tableExtremes: any) {
-    const userMin = new Date(eventMin).toISOString().split('T')[0];
-    const userMax = new Date(eventMax).toISOString().split('T')[0];
-    const selectedMin = this.setDateToFirstOfMonth(frequency, userMin);
-    const selectedMax = this.setDateToFirstOfMonth(frequency, userMax);
-    tableExtremes.emit({ seriesStart: selectedMin, seriesEnd: selectedMax });
-  }
-
-  static setDateToFirstOfMonth(freq: any, date: string) {
-    const month = +date.substring(5, 7);
-    const year = +date.substring(0, 4);
-    const firstOfMonth = {
-      'A': `${year}-01-01`,
-      'Q': `${year}-${this.getQuarterMonths(month)}-01`,
-      'M': `${date.substring(0, 7)}-01`,
-      'S': `${date.substring(0, 7)}-01`
-    }
-    return firstOfMonth[freq] || date;
-  }
   
-  static getQuarterMonths(month: number) {
+  constructor(
+    private helperService: HelperService,
+  ) {
+  }
+
+  getQuarterMonths(month: number) {
     if (month >= 1 && month <= 3) {
       return '01';
     }
@@ -73,7 +59,32 @@ export class HighstockHelperService {
       return '10';
     }
   }
-  constructor() { }
+
+  setDateToFirstOfMonth(freq: any, date: string) {
+    const month = +date.substring(5, 7);
+    const year = +date.substring(0, 4);
+    const firstOfMonth = {
+      'A': `${year}-01-01`,
+      'Q': `${year}-${this.getQuarterMonths(month)}-01`,
+      'M': `${date.substring(0, 7)}-01`,
+      'S': `${date.substring(0, 7)}-01`
+    }
+    return firstOfMonth[freq] || date;
+  }
+
+  rangeSelectorSetExtremesEvent(eventMin, eventMax, frequency: string, tableExtremes: any) {
+    const userMin = new Date(eventMin).toISOString().split('T')[0];
+    const userMax = new Date(eventMax).toISOString().split('T')[0];
+    const selectedMin = this.setDateToFirstOfMonth(frequency, userMin);
+    const selectedMax = this.setDateToFirstOfMonth(frequency, userMax);
+    this.helperService.updateCurrentDateRange({
+      startDate: selectedMin,
+      endDate: selectedMax,
+      endOfSample: false,
+      useDefaultRange: false
+    });
+    tableExtremes.emit({ seriesStart: selectedMin, seriesEnd: selectedMax });
+  }
 
   freqInterval = (freq: string) => {
     const interval = {

--- a/projects/tools/src/lib/highstock/highstock.component.html
+++ b/projects/tools/src/lib/highstock/highstock.component.html
@@ -1,2 +1,2 @@
-<highcharts-chart id="single-stock-chart" *ngIf="showChart" [Highcharts]="Highcharts"
+<highcharts-chart id="single-stock-chart" [Highcharts]="Highcharts"
   [constructorType]="chartConstructor" [options]="chartOptions" [(update)]="updateChart" (chartInstance)="saveChartInstance($event)"></highcharts-chart>

--- a/projects/tools/src/lib/highstock/highstock.component.ts
+++ b/projects/tools/src/lib/highstock/highstock.component.ts
@@ -27,7 +27,7 @@ export class HighstockComponent implements OnChanges {
   @Input() end: string;
   @Input() showTitle: boolean;
   // Async EventEmitter, emit tableExtremes on load to render table
-  @Output() tableExtremes = new EventEmitter(true);
+  @Output() xAxisExtremes = new EventEmitter(true);
   updateChart = false;
   chartObject: Highcharts.Chart;
   showChart = false;
@@ -117,8 +117,9 @@ export class HighstockComponent implements OnChanges {
     const startDate = this.start ? this.start : null;
     const endDate = this.setEndDate(this.end, chartRange, chartData);
     const series = this.formatChartSeries(chartData, portalSettings, seriesDetail, freq);
-    const tableExtremes = this.tableExtremes;
-    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, tableExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, tableExtremes)
+    const { dates } = chartData;
+    const xAxisExtremes = this.xAxisExtremes;
+    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, dates, xAxisExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, dates, xAxisExtremes)
     const formatTooltip = (
         points: Array<Highcharts.TooltipFormatterContextObject>,
         x: Highcharts.PointLabelObject['x'],
@@ -235,8 +236,7 @@ export class HighstockComponent implements OnChanges {
       events: {
         setExtremes(e) {
           if (e.trigger === 'rangeSelectorButton') {
-            console.log('e', e)
-            rangeSelectorSetExtremes(e.min, e.max, freq.freq, tableExtremes);
+            rangeSelectorSetExtremes(e.min, e.max, freq.freq, dates, xAxisExtremes);
           }
         }
       },

--- a/projects/tools/src/lib/highstock/highstock.component.ts
+++ b/projects/tools/src/lib/highstock/highstock.component.ts
@@ -137,7 +137,7 @@ export class HighstockComponent implements OnChanges {
       };
     const logo = this.logo;
     const addToAnalyzer = (seriesId: number) => this.analyzerService.addToAnalyzer(seriesId);
-    const rmvFromAnalyzer = (seriesId: number) => this.analyzerService.removeFromAnalyzer(seriesId);
+    const rmvFromAnalyzer = (seriesId: number) => this.analyzerService.removeFromAnalyzer(seriesId, startDate);
     this.chartOptions.accessibility.description = accessibilityDescription;
     this.chartOptions.chart.events = {
       render() {

--- a/projects/tools/src/lib/highstock/highstock.component.ts
+++ b/projects/tools/src/lib/highstock/highstock.component.ts
@@ -118,6 +118,7 @@ export class HighstockComponent implements OnChanges {
     const endDate = this.setEndDate(this.end, chartRange, chartData);
     const series = this.formatChartSeries(chartData, portalSettings, seriesDetail, freq);
     const tableExtremes = this.tableExtremes;
+    const rangeSelectorSetExtremes = (eventMin, eventMax, freq, tableExtremes) => this.highstockHelper.rangeSelectorSetExtremesEvent(eventMin, eventMax, freq, tableExtremes)
     const formatTooltip = (
         points: Array<Highcharts.TooltipFormatterContextObject>,
         x: Highcharts.PointLabelObject['x'],
@@ -234,7 +235,8 @@ export class HighstockComponent implements OnChanges {
       events: {
         setExtremes(e) {
           if (e.trigger === 'rangeSelectorButton') {
-            HighstockHelperService.rangeSelectorSetExtremesEvent(e.min, e.max, freq.freq, tableExtremes);
+            console.log('e', e)
+            rangeSelectorSetExtremes(e.min, e.max, freq.freq, tableExtremes);
           }
         }
       },

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -113,8 +113,8 @@
 						(change)="toggleSASeries($event)">Seasonally Adjusted
 				</label>
 				<lib-date-slider *ngIf="data.displayedMeasurements" class="sliders" [portalSettings]="portalSettings"
-					[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq"
-					(updateRange)="changeRange($event)"></lib-date-slider>
+					[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq" [routeStart]="routeStart"
+					[routeEnd]="routeEnd" (updateRange)="changeRange($event)"></lib-date-slider>
 			</div>
 		</ng-template>
 		<ng-template ngIf [ngIf]="data.requestComplete && !data.noData && !search">

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -133,6 +133,12 @@
 				[freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
 				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
 				[analyzerView]="false" [routeStart]="routeStart" [routeEnd]="routeEnd" (updateURLFragment)="updateRoute()">
+				<!-- <lib-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings"
+				[chartStart]="data.seriesStart" [chartEnd]="data.seriesEnd" [displayedMeasurements]="data.displayedMeasurements"
+				[measurementOrder]="data.measurementOrder" [dates]="data.categoryDates"
+				[freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
+				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
+				[analyzerView]="false" (updateURLFragment)="updateRoute()"> -->
 			</lib-category-charts>
 		</ng-template>
 		<ng-template ngIf [ngIf]="data.requestComplete && data.noData && !search">

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -129,8 +129,8 @@
 			<lib-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings"
 				[displayedMeasurements]="data.displayedMeasurements" [measurementOrder]="data.measurementOrder"
 				[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
-				[dateRange]="selectedDateRange" [showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax"
-				[hasSeasonal]="data.hasSeasonal" [analyzerView]="false" (updateURLFragment)="updateRoute()">
+				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
+				[analyzerView]="false" (updateURLFragment)="updateRoute()">
 			</lib-category-charts>
 		</ng-template>
 		<ng-template ngIf [ngIf]="data.requestComplete && data.noData && !search">

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -113,12 +113,12 @@
 						(change)="toggleSASeries($event)">Seasonally Adjusted
 				</label>
 				<lib-date-slider *ngIf="data.displayedMeasurements" class="sliders" [portalSettings]="portalSettings"
-					[dates]="data.categoryDates" [dateFrom]="routeStart || null"
-					[dateTo]="routeEnd ? routeEnd : data.seriesEnd || null" [freq]="selectedFreq?.freq || data.currentFreq.freq"
-					(updateRange)="changeRange($event, data)"></lib-date-slider>
+					[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq"
+					(updateRange)="changeRange($event)"></lib-date-slider>
 			</div>
 		</ng-template>
-		<ng-template ngIf [ngIf]="data.requestComplete && !data.noData && seriesRange && !search">
+		<!-- <ng-template ngIf [ngIf]="data.requestComplete && !data.noData && seriesRange && !search"> -->
+			<ng-template ngIf [ngIf]="data.requestComplete && !data.noData && !search">
 			<lib-category-table-view *ngIf="routeView === 'table'" [portalSettings]="portalSettings"
 				[measurementOrder]="data.measurementOrder" [displayedMeasurements]="data.displayedMeasurements"
 				[dates]="data.categoryDates" [tableStart]="routeStart" [tableEnd]="routeEnd"
@@ -131,6 +131,7 @@
 				[chartStart]="data.seriesStart" [chartEnd]="data.seriesEnd" [displayedMeasurements]="data.displayedMeasurements"
 				[measurementOrder]="data.measurementOrder" [dates]="data.categoryDates"
 				[freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
+				[dateRange]="selectedDateRange"
 				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
 				[analyzerView]="false" [routeStart]="routeStart" [routeEnd]="routeEnd" (updateURLFragment)="updateRoute()">
 				<!-- <lib-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings"

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -117,29 +117,20 @@
 					(updateRange)="changeRange($event)"></lib-date-slider>
 			</div>
 		</ng-template>
-		<!-- <ng-template ngIf [ngIf]="data.requestComplete && !data.noData && seriesRange && !search"> -->
-			<ng-template ngIf [ngIf]="data.requestComplete && !data.noData && !search">
+		<ng-template ngIf [ngIf]="data.requestComplete && !data.noData && !search">
 			<lib-category-table-view *ngIf="routeView === 'table'" [portalSettings]="portalSettings"
 				[measurementOrder]="data.measurementOrder" [displayedMeasurements]="data.displayedMeasurements"
-				[dates]="data.categoryDates" [tableStart]="routeStart" [tableEnd]="routeEnd"
-				[selectedCategory]="data.selectedCategory" [selectedDataList]="data.selectedDataList"
-				[yoyActive]="queryParams.yoy === 'true'" [ytdActive]="queryParams.ytd === 'true'" [noSeries]="data.noData"
-				[params]="queryParams" [c5maActive]="queryParams.c5ma === 'true'" [showSeasonal]="queryParams.sa === 'true'"
+				[dates]="data.categoryDates" [selectedCategory]="data.selectedCategory"
+				[selectedDataList]="data.selectedDataList" [yoyActive]="queryParams.yoy === 'true'"
+				[ytdActive]="queryParams.ytd === 'true'" [noSeries]="data.noData" [params]="queryParams"
+				[c5maActive]="queryParams.c5ma === 'true'" [showSeasonal]="queryParams.sa === 'true'"
 				[hasSeasonal]="data.hasSeasonal">
 			</lib-category-table-view>
 			<lib-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings"
-				[chartStart]="data.seriesStart" [chartEnd]="data.seriesEnd" [displayedMeasurements]="data.displayedMeasurements"
-				[measurementOrder]="data.measurementOrder" [dates]="data.categoryDates"
-				[freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
-				[dateRange]="selectedDateRange"
-				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
-				[analyzerView]="false" [routeStart]="routeStart" [routeEnd]="routeEnd" (updateURLFragment)="updateRoute()">
-				<!-- <lib-category-charts *ngIf="routeView !== 'table'" [portalSettings]="portalSettings"
-				[chartStart]="data.seriesStart" [chartEnd]="data.seriesEnd" [displayedMeasurements]="data.displayedMeasurements"
-				[measurementOrder]="data.measurementOrder" [dates]="data.categoryDates"
-				[freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
-				[showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax" [hasSeasonal]="data.hasSeasonal"
-				[analyzerView]="false" (updateURLFragment)="updateRoute()"> -->
+				[displayedMeasurements]="data.displayedMeasurements" [measurementOrder]="data.measurementOrder"
+				[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq" [noSeries]="data.noData"
+				[dateRange]="selectedDateRange" [showSeasonal]="queryParams.sa === 'true'" [findMinMax]="data.findMinMax"
+				[hasSeasonal]="data.hasSeasonal" [analyzerView]="false" (updateURLFragment)="updateRoute()">
 			</lib-category-charts>
 		</ng-template>
 		<ng-template ngIf [ngIf]="data.requestComplete && data.noData && !search">

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -4,10 +4,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CategoryHelperService } from '../category-helper.service';
 import { HelperService } from '../helper.service';
 import { DataPortalSettingsService } from '../data-portal-settings.service';
-import { Frequency, Geography } from '../tools.models';
+import { Frequency, Geography, DateRange } from '../tools.models';
 import { Subscription } from 'rxjs';
-import { DialogModule } from 'primeng/dialog';
-import { TabViewModule } from 'primeng/tabview';
 
 @Component({
   selector: 'lib-landing-page',
@@ -35,9 +33,11 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   freqSub: Subscription;
   fcSub: Subscription;
   geoSub: Subscription;
+  dateRangeSub: Subscription;
   selectedGeo: Geography;
   selectedFreq: Frequency;
   selectedFc: string;
+  selectedDateRange: DateRange;
 
   constructor(
     @Inject('portal') public portal,
@@ -48,6 +48,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     private router: Router,
   ) {
     this.freqSub = helperService.currentFreq.subscribe((freq) => {
+      console.log('selectedFreq', freq)
       this.selectedFreq = freq;
     });
     this.geoSub = helperService.currentGeo.subscribe((geo) => {
@@ -55,7 +56,11 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     });
     this.fcSub = helperService.currentFc.subscribe((fc) => {
       this.selectedFc = fc;
-    })
+    });
+    this.dateRangeSub = helperService.currentDateRange.subscribe((dateRange) => {
+      console.log('current date range', dateRange)
+      this.selectedDateRange = dateRange;
+    });
   }
 
   ngOnInit(): void {
@@ -107,6 +112,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     }
     this.freqSub.unsubscribe();
     this.geoSub.unsubscribe();
+    this.dateRangeSub.unsubscribe();
   }
 
   // Redraw series when a new measurement is selected
@@ -166,7 +172,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     category.seriesEnd = e.seriesEnd;
     console.log('e', e)
     this.routeStart = e.seriesStart;
-    this.routeEnd = /* e.endOfSample ? null : */ e.seriesEnd;
+    this.routeEnd = e.endOfSample ? null : e.seriesEnd;
     this.seriesRange = e;
     this.queryParams.start = this.routeStart;
     this.queryParams.end = this.routeEnd;

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -48,7 +48,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     private router: Router,
   ) {
     this.freqSub = helperService.currentFreq.subscribe((freq) => {
-      console.log('selectedFreq', freq)
       this.selectedFreq = freq;
     });
     this.geoSub = helperService.currentGeo.subscribe((geo) => {
@@ -58,7 +57,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
       this.selectedFc = fc;
     });
     this.dateRangeSub = helperService.currentDateRange.subscribe((dateRange) => {
-      console.log('current date range', dateRange)
       this.selectedDateRange = dateRange;
       if (dateRange) {
         //this.changeRange(this.selectedDateRange);
@@ -173,7 +171,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   changeRange(e/*,  category */) {
     // category.seriesStart = e.seriesStart;
     // category.seriesEnd = e.seriesEnd;
-    console.log('e', e)
     this.routeStart = e.useDefaultRange ? null : e.startDate;
     this.routeEnd = e.endOfSample ? null : e.endDate;
     //this.seriesRange = e;

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -60,6 +60,9 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     this.dateRangeSub = helperService.currentDateRange.subscribe((dateRange) => {
       console.log('current date range', dateRange)
       this.selectedDateRange = dateRange;
+      if (dateRange) {
+        //this.changeRange(this.selectedDateRange);
+      }
     });
   }
 
@@ -167,13 +170,13 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     this.displayHelp = true;
   }
 
-  changeRange(e, category) {
-    category.seriesStart = e.seriesStart;
-    category.seriesEnd = e.seriesEnd;
+  changeRange(e/*,  category */) {
+    // category.seriesStart = e.seriesStart;
+    // category.seriesEnd = e.seriesEnd;
     console.log('e', e)
-    this.routeStart = e.seriesStart;
-    this.routeEnd = e.endOfSample ? null : e.seriesEnd;
-    this.seriesRange = e;
+    this.routeStart = e.useDefaultRange ? null : e.startDate;
+    this.routeEnd = e.endOfSample ? null : e.endDate;
+    //this.seriesRange = e;
     this.queryParams.start = this.routeStart;
     this.queryParams.end = this.routeEnd;
     this.updateRoute();

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -98,6 +98,20 @@ export class LandingPageComponent implements OnInit, OnDestroy {
       if (this.noCache) { this.queryParams.noCache = this.noCache; } else { delete this.queryParams.noCache; }
       const dataListId = this.dataListId;
       const selectedMeasure = params[`m`];
+      /* if (this.routeStart) {
+        this.helperService.updateCurrentDateRange({
+          startDate: this.routeStart,
+          useDefaultRange: false,
+          ...this.selectedDateRange
+        });
+      }
+      if (this.routeEnd) {
+        this.helperService.updateCurrentDateRange({
+          endDate: this.routeEnd,
+          useDefaultRange: false,
+          ...this.selectedDateRange
+        });
+      } */
       this.categoryData = this.portal.universe === 'nta' ?
         this.catHelper.initContent(this.id, this.noCache, { dataListId, selectedMeasure }) :
         this.catHelper.initContent(this.id, this.noCache, { dataListId, geo, freq, fc })

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -160,12 +160,9 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     this.displayHelp = true;
   }
 
-  changeRange(e/*,  category */) {
-    // category.seriesStart = e.seriesStart;
-    // category.seriesEnd = e.seriesEnd;
+  changeRange(e) {
     this.routeStart = e.useDefaultRange ? null : e.startDate;
     this.routeEnd = e.endOfSample ? null : e.endDate;
-    //this.seriesRange = e;
     this.queryParams.start = this.routeStart;
     this.queryParams.end = this.routeEnd;
     this.updateRoute();

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -33,7 +33,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   freqSub: Subscription;
   fcSub: Subscription;
   geoSub: Subscription;
-  dateRangeSub: Subscription;
   selectedGeo: Geography;
   selectedFreq: Frequency;
   selectedFc: string;
@@ -55,12 +54,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     });
     this.fcSub = helperService.currentFc.subscribe((fc) => {
       this.selectedFc = fc;
-    });
-    this.dateRangeSub = helperService.currentDateRange.subscribe((dateRange) => {
-      this.selectedDateRange = dateRange;
-      if (dateRange) {
-        //this.changeRange(this.selectedDateRange);
-      }
     });
   }
 
@@ -98,20 +91,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
       if (this.noCache) { this.queryParams.noCache = this.noCache; } else { delete this.queryParams.noCache; }
       const dataListId = this.dataListId;
       const selectedMeasure = params[`m`];
-      /* if (this.routeStart) {
-        this.helperService.updateCurrentDateRange({
-          startDate: this.routeStart,
-          useDefaultRange: false,
-          ...this.selectedDateRange
-        });
-      }
-      if (this.routeEnd) {
-        this.helperService.updateCurrentDateRange({
-          endDate: this.routeEnd,
-          useDefaultRange: false,
-          ...this.selectedDateRange
-        });
-      } */
       this.categoryData = this.portal.universe === 'nta' ?
         this.catHelper.initContent(this.id, this.noCache, { dataListId, selectedMeasure }) :
         this.catHelper.initContent(this.id, this.noCache, { dataListId, geo, freq, fc })
@@ -127,7 +106,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     }
     this.freqSub.unsubscribe();
     this.geoSub.unsubscribe();
-    this.dateRangeSub.unsubscribe();
   }
 
   // Redraw series when a new measurement is selected

--- a/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
+++ b/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
@@ -94,8 +94,8 @@ export class PrimengMenuNavComponent implements OnInit, OnDestroy {
       data_list_id: subcategoryId,
       analyzerSeries: null,
       chartSeries: null,
-      start: null,
-      end: null,
+      //start: null,
+      //end: null,
       name: null,
       units: null,
       geography: null

--- a/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
+++ b/projects/tools/src/lib/primeng-menu-nav/primeng-menu-nav.component.ts
@@ -37,7 +37,7 @@ export class PrimengMenuNavComponent implements OnInit, OnDestroy {
     @Inject('portal') private portal,
     public analyzerService: AnalyzerService,
     private activatedRoute: ActivatedRoute,
-    private router: Router
+    private router: Router,
   ) {
     this.analyzerSeriesCount = this.analyzerService.analyzerSeriesCount$.subscribe((data: any) => {
       this.analyzerSeries = data;
@@ -94,11 +94,8 @@ export class PrimengMenuNavComponent implements OnInit, OnDestroy {
       data_list_id: subcategoryId,
       analyzerSeries: null,
       chartSeries: null,
-      //start: null,
-      //end: null,
       name: null,
       units: null,
-      geography: null
     };
   }
 

--- a/projects/tools/src/lib/series-helper.service.ts
+++ b/projects/tools/src/lib/series-helper.service.ts
@@ -149,7 +149,7 @@ export class SeriesHelperService {
       total: 'N/A',
       avg: 'N/A',
       cagr: 'N/A',
-      missing: null,
+      missing: false,
       range: null,
     };
     const { formatNum, formatDate } = this.helperService;

--- a/projects/tools/src/lib/series-helper.service.ts
+++ b/projects/tools/src/lib/series-helper.service.ts
@@ -89,6 +89,7 @@ export class SeriesHelperService {
         this.seriesData.eror = true;
         this.seriesData.requestComplete = true;
       });
+      console.log('SERIES DATA', this.seriesData)
     return observableForkJoin([observableOf(this.seriesData)]);
   }
 

--- a/projects/tools/src/lib/single-series-table/single-series-table.component.html
+++ b/projects/tools/src/lib/single-series-table/single-series-table.component.html
@@ -1,6 +1,5 @@
 <div class="series-table">
-  <p-table styleClass="p-datatable-striped" [columns]="tableHeaders" [value]="tableData"
-    [loading]="!seriesData.requestComplete" [loadingIcon]="'spinner-border'">
+  <p-table styleClass="p-datatable-striped" [columns]="tableHeaders" [value]="tableData">
     <ng-template pTemplate="header" let-columns>
       <tr>
         <th *ngFor="let col of columns" [pSortableColumn]="col.field"

--- a/projects/tools/src/lib/single-series-table/single-series-table.component.html
+++ b/projects/tools/src/lib/single-series-table/single-series-table.component.html
@@ -1,0 +1,23 @@
+<div class="series-table">
+  <p-table styleClass="p-datatable-striped" [columns]="tableHeaders" [value]="tableData"
+    [loading]="!seriesData.requestComplete" [loadingIcon]="'spinner-border'">
+    <ng-template pTemplate="header" let-columns>
+      <tr>
+        <th *ngFor="let col of columns" [pSortableColumn]="col.field"
+          [pSortableColumnDisabled]="col.field !== 'tableDate'">
+          {{col.header}}
+          <p-sortIcon *ngIf="col.field === 'tableDate'" [field]="col.field" ariaLabel="Activate to sort"
+            ariaLabelDesc="Activate to sort in descending order" ariaLabelAsc="Activate to sort in ascending order">
+          </p-sortIcon>
+        </th>
+      </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-rowData let-columns="columns">
+      <tr>
+        <td *ngFor="let col of columns">
+          {{rowData[col.field]}}
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+</div>

--- a/projects/tools/src/lib/single-series-table/single-series-table.component.spec.ts
+++ b/projects/tools/src/lib/single-series-table/single-series-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SingleSeriesTableComponent } from './single-series-table.component';
+
+describe('SingleSeriesTableComponent', () => {
+  let component: SingleSeriesTableComponent;
+  let fixture: ComponentFixture<SingleSeriesTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SingleSeriesTableComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SingleSeriesTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/tools/src/lib/single-series-table/single-series-table.component.ts
+++ b/projects/tools/src/lib/single-series-table/single-series-table.component.ts
@@ -1,0 +1,79 @@
+import { Component, Input, OnInit, OnDestroy, Inject } from '@angular/core';
+import { HelperService } from '../helper.service';
+import { DateRange } from '../tools.models';
+import { Subscription } from 'rxjs';
+import { DataPortalSettingsService } from '../data-portal-settings.service';
+
+@Component({
+  selector: 'lib-single-series-table',
+  templateUrl: './single-series-table.component.html',
+  styleUrls: ['./single-series-table.component.scss']
+})
+export class SingleSeriesTableComponent implements OnInit, OnDestroy {
+  @Input() seriesData;
+  dateRangeSub: Subscription;
+  tableHeaders: Array<any>;
+  tableData: Array<any>;
+  portalSettings;
+
+  constructor(
+    @Inject('portal') public portal,
+    private dataPortalSettings: DataPortalSettingsService,
+    private helperService: HelperService,
+  ) {}
+
+  ngOnInit() {
+    this.portalSettings = this.dataPortalSettings.dataPortalSettings[this.portal.universe];
+    this.dateRangeSub = this.helperService.currentDateRange.subscribe((dateRange) => {
+      const { seriesDetail, seriesTableData } = this.seriesData;
+      this.drawTable(dateRange, seriesDetail, seriesTableData)
+    }); 
+  }
+
+  ngOnDestroy() {
+    this.dateRangeSub.unsubscribe()
+  }
+
+  drawTable = (selectedDateRange: DateRange, seriesDetail, seriesTableData) => {
+    let tableStart: number;
+    let tableEnd: number;
+    const { startDate, endDate } = selectedDateRange;
+    for (let i = 0; i < seriesTableData.length; i++) {
+      if (seriesTableData[i].date === startDate) {
+        tableStart = i;
+      }
+      if (seriesTableData[i].date === endDate) {
+        tableEnd = i;
+      }
+    }
+    this.tableData = seriesTableData.slice(tableStart, tableEnd + 1).reverse();
+    this.tableHeaders = this.createTableColumns(this.portalSettings, seriesDetail);
+  }
+
+  createTableColumns = (portalSettings, seriesDetail) => {
+    const { frequencyShort, percent } = seriesDetail;
+    const {
+      series1,
+      series2,
+      series2PercLabel,
+      series2Label,
+      columns,
+      series3,
+      series3PercLabel,
+      series3Label
+    } = portalSettings.seriesTable;
+    const cols = [
+      { field: 'tableDate', header: 'Date' },
+      { field: series1, header: 'Level' },
+      {
+        field: series2, header: percent ? series2PercLabel : series2Label
+      }
+    ];
+    if (frequencyShort !== 'A' && columns === 4) {
+      cols.push({
+        field: series3, header: percent ? series3PercLabel : series3Label
+      });
+    }
+    return cols;
+  }
+}

--- a/projects/tools/src/lib/single-series/single-series.component.html
+++ b/projects/tools/src/lib/single-series/single-series.component.html
@@ -36,8 +36,10 @@
       <lib-forecast-selector *ngIf="displayFcSelector" [forecasts]="data.forecastList"
         (selectedFcChange)="updateSelectedForecast(data.siblings, selectedGeo.handle, seasonallyAdjusted, data.forecasts, $event)"
         class="selector"></lib-forecast-selector>
-      <lib-share-link [view]="'series'" [seasonallyAdjusted]="seasonallyAdjusted" [startDate]="startDate"
-        [endDate]="endDate" [seriesId]="data.seriesDetail.id"></lib-share-link>
+
+     <!-- <lib-share-link [view]="'series'" [seasonallyAdjusted]="seasonallyAdjusted" [startDate]="startDate"
+        [endDate]="endDate" [seriesId]="data.seriesDetail.id"></lib-share-link> -->
+
       <div class="form-check" *ngIf="data.saPairAvail">
         <label class="form-check-inline">
           <input type="checkbox" [ngModel]="data.seriesDetail.seasonalAdjustment === 'seasonally_adjusted'"
@@ -45,22 +47,26 @@
           Adjusted
         </label>
       </div>
-      <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
+      <!-- <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
         [dates]="data.sliderDates" [dateFrom]="startDate" [dateTo]="endDate" [freq]="data.seriesDetail.frequencyShort"
-        (updateRange)="changeRange($event, data, data.seriesTableData, data.chartData)"></lib-date-slider>
+        (updateRange)="changeRange($event, data, data.seriesTableData, data.chartData)"></lib-date-slider> -->
+      <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
+        [dates]="data.sliderDates" [freq]="data.seriesDetail.frequencyShort"
+        (updateRange)="changeRange($event, data, data.seriesTableData)"></lib-date-slider>
+
     </div>
     <p *ngIf="noSelection">{{noSelection}}</p>
     <p *ngIf="data.noData">{{data.noData}}</p>
-    <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings" [start]="startDate"
-      [end]="endDate" [chartData]="data.chartData" [seriesDetail]="data.seriesDetail"
-      (tableExtremes)="changeRange($event, data, data.seriesTableData, data.chartData)">
+    <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings" [start]="selectedDateRange.startDate"
+      [end]="selectedDateRange.endDate" [chartData]="data.chartData" [seriesDetail]="data.seriesDetail"
+      (tableExtremes)="changeRange($event, data, data.seriesTableData)">
     </lib-highstock>
     <div class="source" *ngIf="data.seriesDetail.sourceDescription || data.seriesDetail.sourceLink">
       {{data.seriesDetail.sourceDescription}}<br><a href="{{data.seriesDetail.sourceLink}}"
         target="_blank">{{data.seriesDetail.sourceLink}}</a>
       <p innerHTML='{{data.seriesDetail.sourceDetails}}' class="source_detail"></p>
     </div>
-    <div class="summary-stats" *ngIf="!noSelection && !data.noData && summaryStats">
+   <div class="summary-stats" *ngIf="!noSelection && !data.noData && summaryStats">
       <div class="stat">
         <p>Min {{summaryStats.minValueDate}}:<br><b>{{summaryStats.minValue}}</b>
           ({{data.seriesDetail.unitsLabelShort}})</p>
@@ -77,8 +83,10 @@
       </div>
     </div>
     <div class="series-table">
-      <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="tableHeaders"
-        [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'">
+      <!-- <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="tableHeaders"
+        [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'"> -->
+        <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="drawTable(selectedDateRange, data, data.seriesTableData, data.chartData).tableHeaders"
+        [value]="drawTable(selectedDateRange, data, data.seriesTableData, data.chartData).newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'"> 
         <ng-template pTemplate="header" let-columns>
           <tr>
             <th *ngFor="let col of columns" [pSortableColumn]="col.field"

--- a/projects/tools/src/lib/single-series/single-series.component.html
+++ b/projects/tools/src/lib/single-series/single-series.component.html
@@ -66,27 +66,10 @@
         target="_blank">{{data.seriesDetail.sourceLink}}</a>
       <p innerHTML='{{data.seriesDetail.sourceDetails}}' class="source_detail"></p>
     </div>
-   <div class="summary-stats" *ngIf="!noSelection && !data.noData && summaryStats">
-      <div class="stat">
-        <p>Min {{summaryStats.minValueDate}}:<br><b>{{summaryStats.minValue}}</b>
-          ({{data.seriesDetail.unitsLabelShort}})</p>
-      </div>
-      <div class="stat">
-        <p>Max {{summaryStats.maxValueDate}}:<br><b>{{summaryStats.maxValue}}</b>
-          ({{data.seriesDetail.unitsLabelShort}})</p>
-      </div>
-      <div class="stat" *ngIf="!data.seriesDetail.percent">
-        <p>% Change over Selected Range:<br><b>{{summaryStats.percChange}}</b></p>
-      </div>
-      <div class="stat">
-        <p>Change over Selected Range:<br><b>{{summaryStats.levelChange}}</b></p>
-      </div>
-    </div>
-    <div class="series-table">
-      <!-- <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="tableHeaders"
-        [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'"> -->
-        <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="drawTable(selectedDateRange, data, data.seriesTableData, data.chartData).tableHeaders"
-        [value]="drawTable(selectedDateRange, data, data.seriesTableData, data.chartData).newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'"> 
+    <lib-summary-statistics *ngIf="data.requestComplete" [seriesData]="data"></lib-summary-statistics>
+    <!-- <div class="series-table">
+      <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="tableHeaders"
+        [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'">
         <ng-template pTemplate="header" let-columns>
           <tr>
             <th *ngFor="let col of columns" [pSortableColumn]="col.field"
@@ -106,6 +89,7 @@
           </tr>
         </ng-template>
       </p-table>
-    </div>
+    </div> -->
+    <lib-single-series-table *ngIf="!noSelection && !data.noData" [seriesData]="data"></lib-single-series-table>
   </div>
 </div>

--- a/projects/tools/src/lib/single-series/single-series.component.html
+++ b/projects/tools/src/lib/single-series/single-series.component.html
@@ -1,95 +1,78 @@
 <div *ngFor="let data of seriesData | async" class="single-series-view col-xs-12 col-sm-12 col-xl-11">
-  <p *ngIf="data.error">Series does not exist.</p>
-  <div *ngIf="!data.error">
-    <h3 class="series-title">{{data.seriesDetail.title}}</h3><i (click)="showHelp()"
-      class="bi bi-question-circle display-help-icon"></i>
-    <p-dialog header="Series View Help" [(visible)]="displayHelp" [style]="{width: '60vw'}" [modal]="true"
-      [dismissableMask]="true">
-      <p>The series view plots a single indicator using a line measured on the right axis and the year-over-year percent
-        change (or absolute change) displayed as bars measured on the left axis.</p>
-      <p>At the top of the chart, in addition to the familiar selector boxes, you can also toggle whether the chart
-        displays seasonally-adjusted indicators or the non-seasonally-adjusted indicator if both are available. The
-        share button next to the frequency selector opens a dialog box containing a static URL to this series which can
-        be bookmarked, shared or otherwise used to reproduce the chart as it appears on the screen, as well as, an embed
-        code. As in each of the other views, to add an indicator to the Analyzer, toggle the star, located at the bottom
-        left corner of the chart.
-      </p>
-      <p>To control the selected sample of data, use the slider located above the chart. The dates can be selected by
-        either clicking and dragging the handles of the slider or by clicking the input boxes and entering a date
-        manually. There is also a set of buttons at the top left-hand corner of the chart to set the range of data to 1
-        Year (for non-annual series), 5 Years, or 10 Years from the selected starting date. The 'All' button will
-        display all available data.
-      </p>
-      <p>Below the chart is the source of the data, a link to the source agency, and any relevant notes followed by a
-        row of summary statistics measured over the currently selected range and a table displaying the data with the
-        option of sorting by date either ascending or descending.</p>
-      <p>In the top-right corner of the chart area, click Download to choose from PNG, JPEG, SVG, PDF or CSV exports of
-        the selected data.</p>
-    </p-dialog>
-    <div class="filters">
-      <lib-geo-selector *ngIf="data.regions" [regions]="data.regions"
-        (selectedGeoChange)="goToSeries(data.siblings, selectedFreq.freq, $event.handle, seasonallyAdjusted)"
-        class="geo-selector"></lib-geo-selector>
-      <lib-freq-selector *ngIf="portal !== 'nta' && data.frequencies" [freqs]="data.frequencies"
-        (selectedFreqChange)="goToSeries(data.siblings, $event.freq, selectedGeo.handle, seasonallyAdjusted)"
-        class="freq-selector"></lib-freq-selector>
-      <lib-forecast-selector *ngIf="displayFcSelector" [forecasts]="data.forecastList"
-        (selectedFcChange)="updateSelectedForecast(data.siblings, selectedGeo.handle, seasonallyAdjusted, data.forecasts, $event)"
-        class="selector"></lib-forecast-selector>
-
-     <!-- <lib-share-link [view]="'series'" [seasonallyAdjusted]="seasonallyAdjusted" [startDate]="startDate"
-        [endDate]="endDate" [seriesId]="data.seriesDetail.id"></lib-share-link> -->
-
-      <div class="form-check" *ngIf="data.saPairAvail">
-        <label class="form-check-inline">
-          <input type="checkbox" [ngModel]="data.seriesDetail.seasonalAdjustment === 'seasonally_adjusted'"
-            (ngModelChange)="goToSeries(data.siblings, selectedFreq.freq, selectedGeo.handle, $event)">Seasonally
-          Adjusted
-        </label>
+  <ng-template ngIf [ngIf]="!data.requestComplete">
+    <div class="d-flex justify-content-center">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden">Loading...</span>
       </div>
-      <!-- <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-        [dates]="data.sliderDates" [dateFrom]="startDate" [dateTo]="endDate" [freq]="data.seriesDetail.frequencyShort"
-        (updateRange)="changeRange($event, data, data.seriesTableData, data.chartData)"></lib-date-slider> -->
-      <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-        [dates]="data.sliderDates" [freq]="data.seriesDetail.frequencyShort"
-        (updateRange)="changeRange($event, data, data.seriesTableData)"></lib-date-slider>
-
     </div>
-    <p *ngIf="noSelection">{{noSelection}}</p>
-    <p *ngIf="data.noData">{{data.noData}}</p>
-    <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings" [start]="selectedDateRange.startDate"
-      [end]="selectedDateRange.endDate" [chartData]="data.chartData" [seriesDetail]="data.seriesDetail"
-      (tableExtremes)="changeRange($event, data, data.seriesTableData)">
-    </lib-highstock>
-    <div class="source" *ngIf="data.seriesDetail.sourceDescription || data.seriesDetail.sourceLink">
-      {{data.seriesDetail.sourceDescription}}<br><a href="{{data.seriesDetail.sourceLink}}"
-        target="_blank">{{data.seriesDetail.sourceLink}}</a>
-      <p innerHTML='{{data.seriesDetail.sourceDetails}}' class="source_detail"></p>
+  </ng-template>
+  <ng-template ngIf [ngIf]="data.requestComplete">
+    <p *ngIf="data.error">Series does not exist.</p>
+    <div *ngIf="!data.error">
+      <h3 class="series-title">{{data.seriesDetail.title}}</h3><i (click)="showHelp()"
+        class="bi bi-question-circle display-help-icon"></i>
+      <p-dialog header="Series View Help" [(visible)]="displayHelp" [style]="{width: '60vw'}" [modal]="true"
+        [dismissableMask]="true">
+        <p>The series view plots a single indicator using a line measured on the right axis and the year-over-year percent
+          change (or absolute change) displayed as bars measured on the left axis.</p>
+        <p>At the top of the chart, in addition to the familiar selector boxes, you can also toggle whether the chart
+          displays seasonally-adjusted indicators or the non-seasonally-adjusted indicator if both are available. The
+          share button next to the frequency selector opens a dialog box containing a static URL to this series which can
+          be bookmarked, shared or otherwise used to reproduce the chart as it appears on the screen, as well as, an embed
+          code. As in each of the other views, to add an indicator to the Analyzer, toggle the star, located at the bottom
+          left corner of the chart.
+        </p>
+        <p>To control the selected sample of data, use the slider located above the chart. The dates can be selected by
+          either clicking and dragging the handles of the slider or by clicking the input boxes and entering a date
+          manually. There is also a set of buttons at the top left-hand corner of the chart to set the range of data to 1
+          Year (for non-annual series), 5 Years, or 10 Years from the selected starting date. The 'All' button will
+          display all available data.
+        </p>
+        <p>Below the chart is the source of the data, a link to the source agency, and any relevant notes followed by a
+          row of summary statistics measured over the currently selected range and a table displaying the data with the
+          option of sorting by date either ascending or descending.</p>
+        <p>In the top-right corner of the chart area, click Download to choose from PNG, JPEG, SVG, PDF or CSV exports of
+          the selected data.</p>
+      </p-dialog>
+      <div class="filters">
+        <lib-geo-selector *ngIf="data.regions" [regions]="data.regions"
+          (selectedGeoChange)="goToSeries(data.siblings, selectedFreq.freq, $event.handle, seasonallyAdjusted)"
+          class="geo-selector"></lib-geo-selector>
+        <lib-freq-selector *ngIf="portal !== 'nta' && data.frequencies" [freqs]="data.frequencies"
+          (selectedFreqChange)="goToSeries(data.siblings, $event.freq, selectedGeo.handle, seasonallyAdjusted)"
+          class="freq-selector"></lib-freq-selector>
+        <lib-forecast-selector *ngIf="displayFcSelector" [forecasts]="data.forecastList"
+          (selectedFcChange)="updateSelectedForecast(data.siblings, selectedGeo.handle, seasonallyAdjusted, data.forecasts, $event)"
+          class="selector"></lib-forecast-selector>
+        <lib-share-link [view]="'series'" [seasonallyAdjusted]="seasonallyAdjusted"
+          [startDate]="selectedDateRange.startDate" [endDate]="selectedDateRange.endDate"
+          [seriesId]="data.seriesDetail.id"></lib-share-link>
+        <div class="form-check" *ngIf="data.saPairAvail">
+          <label class="form-check-inline">
+            <input type="checkbox" [ngModel]="data.seriesDetail.seasonalAdjustment === 'seasonally_adjusted'"
+              (ngModelChange)="goToSeries(data.siblings, selectedFreq.freq, selectedGeo.handle, $event)">Seasonally
+            Adjusted
+          </label>
+        </div>
+        <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
+          [dates]="data.sliderDates" [freq]="data.seriesDetail.frequencyShort" [routeStart]="routeStart"
+          [routeEnd]="routeEnd" (updateRange)="changeRange($event)"></lib-date-slider>
+      </div>
+      <p *ngIf="noSelection">{{noSelection}}</p>
+      <p *ngIf="data.noData">{{data.noData}}</p>
+      <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings"
+        [start]="selectedDateRange.startDate" [end]="selectedDateRange.endDate" [chartData]="data.chartData"
+        [seriesDetail]="data.seriesDetail" (xAxisExtremes)="changeRange($event)">
+      </lib-highstock>
+      <div class="source" *ngIf="data.seriesDetail.sourceDescription || data.seriesDetail.sourceLink">
+        {{data.seriesDetail.sourceDescription}}<br><a href="{{data.seriesDetail.sourceLink}}"
+          target="_blank">{{data.seriesDetail.sourceLink}}</a>
+        <p innerHTML='{{data.seriesDetail.sourceDetails}}' class="source_detail"></p>
+      </div>
+      <lib-summary-statistics *ngIf="data.requestComplete" [seriesData]="data"></lib-summary-statistics>
+      <lib-single-series-table *ngIf="!noSelection && !data.noData && data.requestComplete"
+        [seriesData]="data"></lib-single-series-table>
     </div>
-    <lib-summary-statistics *ngIf="data.requestComplete" [seriesData]="data"></lib-summary-statistics>
-    <!-- <div class="series-table">
-      <p-table *ngIf="!noSelection && !data.noData" styleClass="p-datatable-striped" [columns]="tableHeaders"
-        [value]="newTableData" [loading]="!data.requestComplete" [loadingIcon]="'spinner-border'">
-        <ng-template pTemplate="header" let-columns>
-          <tr>
-            <th *ngFor="let col of columns" [pSortableColumn]="col.field"
-              [pSortableColumnDisabled]="col.field !== 'tableDate'">
-              {{col.header}}
-              <p-sortIcon *ngIf="col.field === 'tableDate'" [field]="col.field" ariaLabel="Activate to sort"
-                ariaLabelDesc="Activate to sort in descending order" ariaLabelAsc="Activate to sort in ascending order">
-              </p-sortIcon>
-            </th>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="body" let-rowData let-columns="columns">
-          <tr>
-            <td *ngFor="let col of columns">
-              {{rowData[col.field]}}
-            </td>
-          </tr>
-        </ng-template>
-      </p-table>
-    </div> -->
-    <lib-single-series-table *ngIf="!noSelection && !data.noData" [seriesData]="data"></lib-single-series-table>
-  </div>
+  
+  </ng-template>
 </div>

--- a/projects/tools/src/lib/single-series/single-series.component.html
+++ b/projects/tools/src/lib/single-series/single-series.component.html
@@ -13,25 +13,31 @@
         class="bi bi-question-circle display-help-icon"></i>
       <p-dialog header="Series View Help" [(visible)]="displayHelp" [style]="{width: '60vw'}" [modal]="true"
         [dismissableMask]="true">
-        <p>The series view plots a single indicator using a line measured on the right axis and the year-over-year percent
+        <p>The series view plots a single indicator using a line measured on the right axis and the year-over-year
+          percent
           change (or absolute change) displayed as bars measured on the left axis.</p>
         <p>At the top of the chart, in addition to the familiar selector boxes, you can also toggle whether the chart
           displays seasonally-adjusted indicators or the non-seasonally-adjusted indicator if both are available. The
-          share button next to the frequency selector opens a dialog box containing a static URL to this series which can
-          be bookmarked, shared or otherwise used to reproduce the chart as it appears on the screen, as well as, an embed
-          code. As in each of the other views, to add an indicator to the Analyzer, toggle the star, located at the bottom
+          share button next to the frequency selector opens a dialog box containing a static URL to this series which
+          can
+          be bookmarked, shared or otherwise used to reproduce the chart as it appears on the screen, as well as, an
+          embed
+          code. As in each of the other views, to add an indicator to the Analyzer, toggle the star, located at the
+          bottom
           left corner of the chart.
         </p>
         <p>To control the selected sample of data, use the slider located above the chart. The dates can be selected by
           either clicking and dragging the handles of the slider or by clicking the input boxes and entering a date
-          manually. There is also a set of buttons at the top left-hand corner of the chart to set the range of data to 1
+          manually. There is also a set of buttons at the top left-hand corner of the chart to set the range of data to
+          1
           Year (for non-annual series), 5 Years, or 10 Years from the selected starting date. The 'All' button will
           display all available data.
         </p>
         <p>Below the chart is the source of the data, a link to the source agency, and any relevant notes followed by a
           row of summary statistics measured over the currently selected range and a table displaying the data with the
           option of sorting by date either ascending or descending.</p>
-        <p>In the top-right corner of the chart area, click Download to choose from PNG, JPEG, SVG, PDF or CSV exports of
+        <p>In the top-right corner of the chart area, click Download to choose from PNG, JPEG, SVG, PDF or CSV exports
+          of
           the selected data.</p>
       </p-dialog>
       <div class="filters">
@@ -60,8 +66,7 @@
       </div>
       <p *ngIf="noSelection">{{noSelection}}</p>
       <p *ngIf="data.noData">{{data.noData}}</p>
-      <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings"
-        [start]="selectedDateRange.startDate" [end]="selectedDateRange.endDate" [chartData]="data.chartData"
+      <lib-highstock *ngIf="!noSelection && !data.noData" [portalSettings]="portalSettings" [chartData]="data.chartData"
         [seriesDetail]="data.seriesDetail" (xAxisExtremes)="changeRange($event)">
       </lib-highstock>
       <div class="source" *ngIf="data.seriesDetail.sourceDescription || data.seriesDetail.sourceLink">
@@ -73,6 +78,6 @@
       <lib-single-series-table *ngIf="!noSelection && !data.noData && data.requestComplete"
         [seriesData]="data"></lib-single-series-table>
     </div>
-  
+
   </ng-template>
 </div>

--- a/projects/tools/src/lib/single-series/single-series.component.scss
+++ b/projects/tools/src/lib/single-series/single-series.component.scss
@@ -59,24 +59,6 @@
       margin-bottom: 0;
     }
   }
-
-  .summary-stats {
-    width: 100%;
-    display: table;
-    table-layout: fixed;
-    padding: 10px 0;
-    margin: 1% 0;
-    
-    .stat {
-      display: table-cell;
-      text-align: center;
-      font-size: 0.9em;
-
-      p {
-        margin-bottom: 0;
-      }
-    }
-  }
   
   .selectors {
     margin: 0 auto;

--- a/projects/tools/src/lib/single-series/single-series.component.ts
+++ b/projects/tools/src/lib/single-series/single-series.component.ts
@@ -19,8 +19,6 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
   tableHeaders;
   summaryStats;
   seasonallyAdjusted = false;
-  // startDate;
-  // endDate;
   chartStart;
   chartEnd;
   portalSettings;
@@ -133,8 +131,6 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
         start: this.routeStart ? this.routeStart : null,
         end: this.routeEnd ? this.routeEnd : null
       };
-      // this.startDate = this.chartStart;
-      // this.endDate = this.chartEnd;
       this.router.navigate(['/series/'], { queryParams, queryParamsHandling: 'merge' });
     } else {
       this.noSelection = 'Selection Not Available';

--- a/projects/tools/src/lib/single-series/single-series.component.ts
+++ b/projects/tools/src/lib/single-series/single-series.component.ts
@@ -152,7 +152,7 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
 
   removeFromAnalyzer(series) {
     series.analyze = false;
-    this.analyzerService.removeFromAnalyzer(series.id);
+    this.analyzerService.removeFromAnalyzer(series.id, this.selectedDateRange.startDate);
   }
 
   changeRange(dateRange: DateRange) {

--- a/projects/tools/src/lib/single-series/single-series.component.ts
+++ b/projects/tools/src/lib/single-series/single-series.component.ts
@@ -276,7 +276,7 @@ export class SingleSeriesComponent implements OnInit/*, AfterViewInit*/, OnDestr
     // this.endDate = seriesEnd;
     const { seriesDetail, chartData } = data;
     const { startDate, endDate } = this.selectedDateRange;
-    this.summaryStats = this.seriesHelper.calculateSeriesSummaryStats(seriesDetail, chartData, startDate, endDate, false, null);
-    this.drawTable(this.selectedDateRange, data, tableData, chartData);
+    //this.summaryStats = this.seriesHelper.calculateSeriesSummaryStats(seriesDetail, chartData, startDate, endDate, false, null);
+    //this.drawTable(this.selectedDateRange, data, tableData, chartData);
   }
 }

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.html
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.html
@@ -1,0 +1,16 @@
+<div class="summary-stats">
+  <div class="stat">
+    <p>Min {{summaryStats.minValueDate}}:<br><b>{{summaryStats.minValue}}</b>
+      ({{seriesData.seriesDetail.unitsLabelShort}})</p>
+  </div>
+  <div class="stat">
+    <p>Max {{summaryStats.maxValueDate}}:<br><b>{{summaryStats.maxValue}}</b>
+      ({{seriesData.seriesDetail.unitsLabelShort}})</p>
+  </div>
+  <div class="stat" *ngIf="!seriesData.seriesDetail.percent">
+    <p>% Change over Selected Range:<br><b>{{summaryStats.percChange}}</b></p>
+  </div>
+  <div class="stat">
+    <p>Change over Selected Range:<br><b>{{summaryStats.levelChange}}</b></p>
+  </div>
+</div>

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.scss
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.scss
@@ -1,0 +1,17 @@
+.summary-stats {
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+  padding: 10px 0;
+  margin: 1% 0;
+  
+  .stat {
+    display: table-cell;
+    text-align: center;
+    font-size: 0.9em;
+
+    p {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.spec.ts
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SummaryStatisticsComponent } from './summary-statistics.component';
+
+describe('SummaryStatisticsComponent', () => {
+  let component: SummaryStatisticsComponent;
+  let fixture: ComponentFixture<SummaryStatisticsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SummaryStatisticsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SummaryStatisticsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
@@ -1,0 +1,39 @@
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { HelperService } from '../helper.service';
+import { SeriesHelperService } from '../series-helper.service';
+import { Frequency, Geography, DateRange } from '../tools.models';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'lib-summary-statistics',
+  templateUrl: './summary-statistics.component.html',
+  styleUrls: ['./summary-statistics.component.scss']
+})
+export class SummaryStatisticsComponent implements OnInit, OnDestroy {
+  @Input() seriesData;
+  selectedDateRange: DateRange;
+  dateRangeSub: Subscription;
+  summaryStats;
+
+  constructor(
+    private helperService: HelperService,
+    private seriesHelper: SeriesHelperService,
+  ) {
+      
+  }
+
+  ngOnInit() {
+    this.dateRangeSub = this.helperService.currentDateRange.subscribe((dateRange) => {
+      this.selectedDateRange = dateRange;
+      console.log('stats component seriesData', this.seriesData)
+      console.log('stats component dateRange', dateRange)
+      const { seriesDetail, chartData } = this.seriesData;
+      const { startDate, endDate } = dateRange;
+      this.summaryStats = this.seriesHelper.calculateSeriesSummaryStats(seriesDetail, chartData, startDate, endDate, false, null);
+    });  
+  }
+
+  ngOnDestroy() {
+    this.dateRangeSub.unsubscribe();
+  }
+}

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { HelperService } from '../helper.service';
 import { SeriesHelperService } from '../series-helper.service';
-import { Frequency, Geography, DateRange } from '../tools.models';
+import { DateRange } from '../tools.models';
 import { Subscription } from 'rxjs';
 
 @Component({

--- a/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
+++ b/projects/tools/src/lib/summary-statistics/summary-statistics.component.ts
@@ -25,8 +25,6 @@ export class SummaryStatisticsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.dateRangeSub = this.helperService.currentDateRange.subscribe((dateRange) => {
       this.selectedDateRange = dateRange;
-      console.log('stats component seriesData', this.seriesData)
-      console.log('stats component dateRange', dateRange)
       const { seriesDetail, chartData } = this.seriesData;
       const { startDate, endDate } = dateRange;
       this.summaryStats = this.seriesHelper.calculateSeriesSummaryStats(seriesDetail, chartData, startDate, endDate, false, null);

--- a/projects/tools/src/lib/tools.models.ts
+++ b/projects/tools/src/lib/tools.models.ts
@@ -3,6 +3,12 @@ export interface Frequency {
   label: string;
 }
 
+export interface DateRange {
+  startDate: string,
+  endDate: string,
+  endOfSample: boolean;
+}
+
 export interface Geography {
   fips: number;
   name: string;

--- a/projects/tools/src/lib/tools.models.ts
+++ b/projects/tools/src/lib/tools.models.ts
@@ -158,8 +158,6 @@ export interface AnalyzerDataInterface {
   rightMin: number;
   rightMax: number;
   urlChartSeries: Array<any>;
-  minDate: string;
-  maxDate: string;
   requestComplete: boolean;
   indexed: boolean;
   baseYear: string;

--- a/projects/tools/src/lib/tools.models.ts
+++ b/projects/tools/src/lib/tools.models.ts
@@ -6,7 +6,8 @@ export interface Frequency {
 export interface DateRange {
   startDate: string,
   endDate: string,
-  endOfSample: boolean;
+  useDefaultRange: boolean,
+  endOfSample: boolean
 }
 
 export interface Geography {

--- a/projects/tools/src/lib/tools.module.ts
+++ b/projects/tools/src/lib/tools.module.ts
@@ -37,6 +37,8 @@ import { SearchResultsComponent } from './search-results/search-results.componen
 import { DialogModule } from 'primeng/dialog';
 import { RequestCache } from './request-cache';
 import { CacheInterceptor } from './cache.interceptor';
+import { SummaryStatisticsComponent } from './summary-statistics/summary-statistics.component';
+import { SingleSeriesTableComponent } from './single-series-table/single-series-table.component';
 
 @NgModule({
   declarations: [
@@ -64,6 +66,8 @@ import { CacheInterceptor } from './cache.interceptor';
     MeasurementSelectorComponent,
     EmbedGraphComponent,
     SearchResultsComponent,
+    SummaryStatisticsComponent,
+    SingleSeriesTableComponent,
   ],
   imports: [
     CommonModule,
@@ -105,6 +109,8 @@ import { CacheInterceptor } from './cache.interceptor';
     AnalyzerStatsRendererComponent,
     AnalyzerTableRendererComponent,
     MeasurementSelectorComponent,
+    SummaryStatisticsComponent,
+    SingleSeriesTableComponent
   ],
   providers: [
     RequestCache,

--- a/projects/tools/src/public-api.ts
+++ b/projects/tools/src/public-api.ts
@@ -26,3 +26,5 @@ export * from './lib/analyzer-table-renderer/analyzer-table-renderer.component';
 export * from './lib/analyzer-stats-renderer/analyzer-stats-renderer.component';
 export * from './lib/analyzer-table/analyzer-table.component';
 export * from './lib/measurement-selector/measurement-selector.component';
+export * from './lib/summary-statistics/summary-statistics.component';
+export * from './lib/single-series-table/single-series-table.component';


### PR DESCRIPTION
Pretty large set of changes that addresses the issue of the data portal not displaying the most recent observation when switching regions or frequencies.
It contains a rework of how the data portal determines what date ranges are selected. Rather than passing the starting and ending dates through various nested components in the HTML templates; a service is used where components that rely on drawing data can "listen" for changes made in the date slider/range picker: 
- The 3 main views: Category, Single Series, and Analyzer Views check if a starting (and ending) date are specified in the URL, and passes that to the date slider component. The selected range is stored in the helper service.
- Components that rely on displaying data: Highcharts (grid charts), the single series and analyzer Highstock chart, and the tables in the category and analyzer views subscribe to the date range in the service, listen for changes as the user selects new dates, and updates tables/charts as needed.