### PR TITLE
Bugfix/u 1506

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "highcharts-angular": "^3.0.0",
         "highcharts-export-csv": "^1.4.8",
         "primeicons": "^6.0.1",
-        "primeng": "^15.1.1",
+        "primeng": "^15.4.1",
         "rxjs": "^6.6.7",
         "tether": "^1.4.7",
         "tslib": "^2.3.1",
@@ -11453,19 +11453,18 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "node_modules/primeng": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-15.2.0.tgz",
-      "integrity": "sha512-CLcB4RYiI4PcQ8nwov01L5CQHbhl7n1OufA2OKIq9+C4sBEv9sLsnEN2/Cah4m1jtrRkNbsac8JJE7LdPxecaQ==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-15.4.1.tgz",
+      "integrity": "sha512-j2unOQZk6756l6SgkzcmlHF6JlawF0bIjKTgAPWwT+S5RYeWEjpCPg/ABV8TylwW7CTNQX2oCHbyqCAuhtr++w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^15.1.0",
-        "@angular/core": "^15.1.0",
-        "@angular/forms": "^15.1.0",
-        "primeicons": "^6.0.1",
+        "@angular/common": "^15.2.1",
+        "@angular/core": "^15.2.1",
+        "@angular/forms": "^15.2.1",
         "rxjs": "^6.0.0 || ^7.5.0",
-        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0"
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0"
       }
     },
     "node_modules/proc-log": {
@@ -23130,9 +23129,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "primeng": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-15.2.0.tgz",
-      "integrity": "sha512-CLcB4RYiI4PcQ8nwov01L5CQHbhl7n1OufA2OKIq9+C4sBEv9sLsnEN2/Cah4m1jtrRkNbsac8JJE7LdPxecaQ==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-15.4.1.tgz",
+      "integrity": "sha512-j2unOQZk6756l6SgkzcmlHF6JlawF0bIjKTgAPWwT+S5RYeWEjpCPg/ABV8TylwW7CTNQX2oCHbyqCAuhtr++w==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "highcharts-angular": "^3.0.0",
     "highcharts-export-csv": "^1.4.8",
     "primeicons": "^6.0.1",
-    "primeng": "^15.1.1",
+    "primeng": "^15.4.1",
     "rxjs": "^6.6.7",
     "tether": "^1.4.7",
     "tslib": "^2.3.1",

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -105,7 +105,6 @@ export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy 
           let str = '';
           const { colorIndex, userOptions } = point;
           const { geography, decimals, title, chartData, name } = userOptions;
-          console.log('userOptions', userOptions)
           const decimal = (name.includes('YOY') || name.includes('YTD')) ? 1 : decimals;
           const seriesColor = getSeriesColor(colorIndex);
           const displayName = `${title} (${geography.name})`;

--- a/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
+++ b/projects/tools/src/lib/analyzer-highstock/analyzer-highstock.component.ts
@@ -104,10 +104,12 @@ export class AnalyzerHighstockComponent implements OnInit, OnChanges, OnDestroy 
         const formatSeriesLabel = (point, seriesValue: number, date: string, pointX) => {
           let str = '';
           const { colorIndex, userOptions } = point;
-          const { geography, decimals, title, chartData } = userOptions;
+          const { geography, decimals, title, chartData, name } = userOptions;
+          console.log('userOptions', userOptions)
+          const decimal = (name.includes('YOY') || name.includes('YTD')) ? 1 : decimals;
           const seriesColor = getSeriesColor(colorIndex);
           const displayName = `${title} (${geography.name})`;
-          const value = formatObsValue(seriesValue, decimals);
+          const value = formatObsValue(seriesValue, decimal);
           const label = `${displayName} ${date}: ${value}`;
           const pseudoZones = chartData.pseudoZones;
           if (pseudoZones.length) {

--- a/projects/tools/src/lib/analyzer-table/analyzer-table.component.ts
+++ b/projects/tools/src/lib/analyzer-table/analyzer-table.component.ts
@@ -209,7 +209,7 @@ export class AnalyzerTableComponent implements OnInit, OnChanges, OnDestroy {
       lvlData: false
     };
     formattedDates.forEach((d, index) => {
-      data[d] = this.helperService.formatNum(+values[index], series.decimals);
+      data[d] = +values[index];
     });
     return data;
   }

--- a/projects/tools/src/lib/analyzer/analyzer.component.html
+++ b/projects/tools/src/lib/analyzer/analyzer.component.html
@@ -65,7 +65,7 @@
       </div>
       <div id="analyzer-customizations">
         <lib-freq-selector [freqs]="data.siblingFreqs" [analyzerView]="true"
-          (selectedFreqChange)="changeAnalyzerFrequency($event.freq, data.analyzerSeries)" class="selector">
+          (selectedFreqChange)="changeAnalyzerFrequency($event.freq, data.analyzerFrequency.freq, data.analyzerSeries)" class="selector">
         </lib-freq-selector>
         <label *ngIf="data.requestComplete && data.displayFreqSelector" class="mx-2 form-check-inline">
           <input type="checkbox" (change)="indexActive($event)"
@@ -73,7 +73,7 @@
             [disabled]="!data.displayFreqSelector">Index
         </label>
         <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-          [dates]="data.sliderDates" [routeStart]="routeStart" [routeEnd]="routeEnd"
+          [dates]="data.sliderDates" [previousFreq]="previousFreq" [routeStart]="routeStart" [routeEnd]="routeEnd"
           [freq]="data.analyzerFrequency.freq" (updateRange)="changeRange($event)"></lib-date-slider>
         <button type="button" class="btn btn-sm btn-outline-danger rm-analyzer-series-btn"
           (click)="removeAllAnalyzerSeries()">

--- a/projects/tools/src/lib/analyzer/analyzer.component.ts
+++ b/projects/tools/src/lib/analyzer/analyzer.component.ts
@@ -41,6 +41,7 @@ export class AnalyzerComponent implements OnInit, OnDestroy, AfterContentChecked
   routeEnd: string;
   dateRangeSubscription: Subscription;
   selectedDateRange: DateRange;
+  previousFreq: string = '';
 
   constructor(
     @Inject('environment') private environment,
@@ -160,7 +161,8 @@ export class AnalyzerComponent implements OnInit, OnDestroy, AfterContentChecked
     this.updateUrlLocation();
   }
 
-  changeAnalyzerFrequency(freq, analyzerSeries) {
+  changeAnalyzerFrequency(freq, previousFreq: string, analyzerSeries) {
+    this.previousFreq = previousFreq === freq ? '' : previousFreq;
     const siblingIds = [];
     this.analyzerService.analyzerData.urlChartSeries = [];
     const siblingsList = analyzerSeries.map((serie) => {

--- a/projects/tools/src/lib/category-charts/category-charts.component.html
+++ b/projects/tools/src/lib/category-charts/category-charts.component.html
@@ -3,7 +3,7 @@
 		<ng-template ngFor let-series [ngForOf]="measurement.value">
 			<div [class.seasonal-alert-container]="series.displaySeasonalMessage" class="multi-charts"
 				*ngIf="series.display || series.displaySeasonalMessage">
-				<a href="#" [routerLink]="['/series']" [queryParams]="{id: series.id, sa: series.saParam}"
+				<a href="#" [routerLink]="['/series']" [queryParams]="{id: series.id}"
 					queryParamsHandling='merge' *ngIf="series.id && series.display">
 					<lib-highchart [minValue]="minValue" [maxValue]="maxValue" [portalSettings]="portalSettings"
 						[seriesData]="series" [indexChecked]="indexChecked" [baseYear]="selectedStart">

--- a/projects/tools/src/lib/category-table-render/category-table-render.component.html
+++ b/projects/tools/src/lib/category-table-render/category-table-render.component.html
@@ -1,7 +1,7 @@
 <ng-template ngIf [ngIf]="params.data.lvlData">
   <span>
     <a [class.disabledLink]="params.data.seriesInfo.displaySeasonalMessage ? true : null" class="{{params.data.seriesInfo.indent ? 'indent' + params.data.seriesInfo.indent : ''}}"
-      [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id, sa: params.data.seriesInfo.saParam }"
+      [routerLink]="['/series']" [queryParams]="{ id: params.data.seriesInfo.id }"
       queryParamsHandling='merge'>{{params.value}}</a>
   </span>
   <div class="th-buttons">

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.ts
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.ts
@@ -90,15 +90,15 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
             const seriesData = this.formatLvlData(series, level, dataListId);
             this.rows.push(seriesData);
             if (this.yoyActive) {
-              const yoyData = this.formatTransformationData(series, yoy, 'pc1', 1);
+              const yoyData = this.formatTransformationData(series, yoy, 'pc1');
               if (series.display) { this.rows.push(yoyData); }
             }
             if (this.ytdActive && this.selectedFreq.freq !== 'A') {
-              const ytdData = this.formatTransformationData(series, ytd, 'ytd', 1);
+              const ytdData = this.formatTransformationData(series, ytd, 'ytd');
               if (series.display) { this.rows.push(ytdData); }
             }
             if (this.c5maActive) {
-              const c5maData = this.formatTransformationData(series, c5ma, 'c5ma', series.decimals);
+              const c5maData = this.formatTransformationData(series, c5ma, 'c5ma');
               if (series.display) { this.rows.push(c5maData); }
             }
           }
@@ -167,7 +167,7 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
     return seriesData;
   }
 
-  formatTransformationData = (series, transformation, transformationName, decimals) => {
+  formatTransformationData = (series, transformation, transformationName) => {
     const data = {
       series: '',
       seriesInfo: series,
@@ -178,7 +178,7 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
       const disName = this.formatTransformationName(transformation.transformation, series.percent);
       data.series = disName;
       dates.forEach((d, index) => {
-        data[d] = this.helperService.formatNum(+values[index], decimals);
+        data[d] = +values[index];
       });
       return data;
     }

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.ts
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.ts
@@ -84,21 +84,23 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
         this.displayedMeasurements[measurement].forEach((series) => {
           if (series.display || series.displaySeasonalMessage) {
             series.analyze = this.analyzerService.checkAnalyzer(series);
+            console.log('series', series)
             const transformations = this.helperService.getTransformations(series.seriesObservations.transformationResults);
             const { level, yoy, ytd, c5ma } = transformations;
             const dataListId = this.selectedDataList?.id || null
             const seriesData = this.formatLvlData(series, level, dataListId);
             this.rows.push(seriesData);
             if (this.yoyActive) {
-              const yoyData = this.formatTransformationData(series, yoy, 'pc1');
+              const yoyData = this.formatTransformationData(series, yoy, 'pc1', 1);
+              console.log('yoyData', yoyData)
               if (series.display) { this.rows.push(yoyData); }
             }
             if (this.ytdActive && this.selectedFreq.freq !== 'A') {
-              const ytdData = this.formatTransformationData(series, ytd, 'ytd');
+              const ytdData = this.formatTransformationData(series, ytd, 'ytd', 1);
               if (series.display) { this.rows.push(ytdData); }
             }
             if (this.c5maActive) {
-              const c5maData = this.formatTransformationData(series, c5ma, 'c5ma');
+              const c5maData = this.formatTransformationData(series, c5ma, 'c5ma', series.decimals);
               if (series.display) { this.rows.push(c5maData); }
             }
           }
@@ -167,7 +169,7 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
     return seriesData;
   }
 
-  formatTransformationData = (series, transformation, transformationName) => {
+  formatTransformationData = (series, transformation, transformationName, decimals) => {
     const data = {
       series: '',
       seriesInfo: series,
@@ -178,7 +180,7 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
       const disName = this.formatTransformationName(transformation.transformation, series.percent);
       data.series = disName;
       dates.forEach((d, index) => {
-        data[d] = values[index];
+        data[d] = this.helperService.formatNum(+values[index], decimals);
       });
       return data;
     }

--- a/projects/tools/src/lib/category-table-view/category-table-view.component.ts
+++ b/projects/tools/src/lib/category-table-view/category-table-view.component.ts
@@ -84,7 +84,6 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
         this.displayedMeasurements[measurement].forEach((series) => {
           if (series.display || series.displaySeasonalMessage) {
             series.analyze = this.analyzerService.checkAnalyzer(series);
-            console.log('series', series)
             const transformations = this.helperService.getTransformations(series.seriesObservations.transformationResults);
             const { level, yoy, ytd, c5ma } = transformations;
             const dataListId = this.selectedDataList?.id || null
@@ -92,7 +91,6 @@ export class CategoryTableViewComponent implements OnChanges, OnDestroy {
             this.rows.push(seriesData);
             if (this.yoyActive) {
               const yoyData = this.formatTransformationData(series, yoy, 'pc1', 1);
-              console.log('yoyData', yoyData)
               if (series.display) { this.rows.push(yoyData); }
             }
             if (this.ytdActive && this.selectedFreq.freq !== 'A') {

--- a/projects/tools/src/lib/date-slider/date-slider.component.html
+++ b/projects/tools/src/lib/date-slider/date-slider.component.html
@@ -1,7 +1,6 @@
 <p-calendar #calendarStart [class.annual-calendar]="freq === 'A'" inputId="calendar-start" [view]="calendarView"
   [minDate]="minDateValue" [maxDate]="maxDateValue" [(ngModel)]="calendarStartDate" [placeholder]="placeholderStr"
-  [dateFormat]="calendarStartDateFormat" [yearNavigator]="true" [monthNavigator]="displayMonthNavigator"
-  [disabledDates]="invalidStartDates" [yearRange]="calendarYearRange"
+  [dateFormat]="calendarStartDateFormat" [disabledDates]="invalidStartDates"
   (onSelect)="onCalendarSelect($event, calendarStart.inputId, freq)"
   (onYearChange)="onYearChange($event, calendarStart.inputId, freq)"
   (onMonthChange)="onMonthChange($event, calendarStart.inputId, freq)"
@@ -13,8 +12,7 @@
   (onChange)="onChange($event)" (onSlideEnd)="slideChange($event)"></p-slider>
 <p-calendar #calendarEnd [class.annual-calendar]="freq === 'A'" inputId="calendar-end" [view]="calendarView"
   [minDate]="minDateValue" [maxDate]="maxDateValue" [(ngModel)]="calendarEndDate" [placeholder]="placeholderStr"
-  [dateFormat]="calendarEndDateFormat" [yearNavigator]="true" [monthNavigator]="displayMonthNavigator"
-  [disabledDates]="invalidEndDates" [yearRange]="calendarYearRange"
+  [dateFormat]="calendarEndDateFormat" [disabledDates]="invalidEndDates"
   (onSelect)="onCalendarSelect($event, calendarEnd.inputId, freq)"
   (onYearChange)="onYearChange($event, calendarEnd.inputId, freq)"
   (onMonthChange)="onMonthChange($event, calendarEnd.inputId, freq)"

--- a/projects/tools/src/lib/date-slider/date-slider.component.scss
+++ b/projects/tools/src/lib/date-slider/date-slider.component.scss
@@ -22,9 +22,9 @@ p-calendar.annual-calendar {
 }
 
 p-calendar {
-  button.p-datepicker-prev, button.p-datepicker-next {
+  /* button.p-datepicker-prev, button.p-datepicker-next {
     display: none;
-  }
+  } */
 
   input.p-inputtext {
     padding: 1px 2px;

--- a/projects/tools/src/lib/date-slider/date-slider.component.ts
+++ b/projects/tools/src/lib/date-slider/date-slider.component.ts
@@ -147,14 +147,24 @@ export class DateSliderComponent implements OnChanges {
     // For quarterly and semi-annual series
     // Months not evenly divisible by 3 should be invalidated for quarterly series
     // Month not evenly divisible by 6 should be invalidated for semi-annual series
-    const invalidDates = [];
+    let invalidDates = [];
     const m = freq === 'Q' ? 3 : 6;
     for (let month = 0; month < 12; month++) {
       if ((month % m)) {
-        invalidDates.push(new Date(year, month, 1));
+        invalidDates = invalidDates.concat(this.getAllDaysInMonth(year, month));
       }
     }
     return invalidDates;
+  }
+
+  getAllDaysInMonth = (year: number, month: number) => {
+    let date = new Date(year, month, 1);
+    let dateArray = [];
+    while (date.getMonth() === month) {
+      dateArray.push(new Date(date));
+      date.setDate(date.getDate() + 1);
+    }
+    return dateArray;
   }
 
   getInvalidWeeklyDates = (year: number, month: number) => {

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -312,7 +312,6 @@ export class HelperService {
         levelValue.push(this.createDateValuePairs(level.dates, date.date, level.values));
       }
       if (yoy) {
-        console.log('yoy', yoy)
         yoyValue.push(this.createDateValuePairs(yoy.dates, date.date, yoy.values));
       }
       if (ytd) {
@@ -458,7 +457,6 @@ export class HelperService {
         this.addToTable(level, date, tableObj, 'value', 'formattedValue', decimals);
       }
       if (yoy) {
-        console.log('yoy table value', yoy)
         this.addToTable(yoy, date, tableObj, 'yoyValue', 'formattedYoy', 1);
       }
       if (ytd) {

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -361,9 +361,8 @@ export class HelperService {
       const dateValuePairs = [];
       // YTD and YOY transformations should be rounded to 1 decimal place
       if (t.transformation !== 'lvl' && t.transformation !== 'c5ma') {
-        t.values = t.values.map(val => this.formattedValue(val, 1));
+        t.values = t.values.map(val => this.formattedValue(val, 1).replace(/,/g, ''));
       }
-      console.log('t', t)
       dateArray.forEach((date) => {
         dateValuePairs.push(this.createDateValuePairs(t.dates, date.date, t.values));
       })

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -359,6 +359,10 @@ export class HelperService {
     return transformationResults.map((t) => {
       const pseudoZones = this.getPseudoZones(t);
       const dateValuePairs = [];
+      // YTD and YOY transformations should be rounded to 1 decimal place
+      if (t.transformation !== 'lvl' && t.transformation !== 'c5ma') {
+        t.values = t.values.map(val => this.formattedValue(val, 1));
+      }
       dateArray.forEach((date) => {
         dateValuePairs.push(this.createDateValuePairs(t.dates, date.date, t.values));
       })

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -312,6 +312,7 @@ export class HelperService {
         levelValue.push(this.createDateValuePairs(level.dates, date.date, level.values));
       }
       if (yoy) {
+        console.log('yoy', yoy)
         yoyValue.push(this.createDateValuePairs(yoy.dates, date.date, yoy.values));
       }
       if (ytd) {
@@ -457,10 +458,11 @@ export class HelperService {
         this.addToTable(level, date, tableObj, 'value', 'formattedValue', decimals);
       }
       if (yoy) {
-        this.addToTable(yoy, date, tableObj, 'yoyValue', 'formattedYoy', decimals);
+        console.log('yoy table value', yoy)
+        this.addToTable(yoy, date, tableObj, 'yoyValue', 'formattedYoy', 1);
       }
       if (ytd) {
-        this.addToTable(ytd, date, tableObj, 'ytdValue', 'formattedYtd', decimals);
+        this.addToTable(ytd, date, tableObj, 'ytdValue', 'formattedYtd', 1);
       }
       if (c5ma) {
         this.addToTable(c5ma, date, tableObj, 'c5maValue', 'formattedC5ma', decimals);

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -363,6 +363,7 @@ export class HelperService {
       if (t.transformation !== 'lvl' && t.transformation !== 'c5ma') {
         t.values = t.values.map(val => this.formattedValue(val, 1));
       }
+      console.log('t', t)
       dateArray.forEach((date) => {
         dateValuePairs.push(this.createDateValuePairs(t.dates, date.date, t.values));
       })

--- a/projects/tools/src/lib/helper.service.ts
+++ b/projects/tools/src/lib/helper.service.ts
@@ -258,6 +258,49 @@ export class HelperService {
     return (valueList[middle] !== date) ? -1 : middle;
   }
 
+  // find first date that is greater than or equal to dateToFind
+  binarySearchStartDate = (dateList: Array<any>, dateToFind: string) => {
+    let start = 0;
+    let end = dateList.length - 1;
+    while (start <= end) {
+      const updatedBoundaries = this.findFirstDateGreaterOrEqualTarget(start, end, dateList, dateToFind);
+      start = updatedBoundaries.start;
+      end = updatedBoundaries.end;
+    }
+    return start;
+  }
+
+  binarySearchEndDate = (dateList: Array<any>, dateToFind: string) => {
+    let start = 0;
+    let end = dateList.length - 1;
+    while (start <= end) {
+      const updatedBoundaries = this.findLastDateLessOrEqualTarget(start, end, dateList, dateToFind);
+      start = updatedBoundaries.start;
+      end = updatedBoundaries.end;
+    }
+    return end;
+  }
+
+  findLastDateLessOrEqualTarget = (start: number, end: number, dateList: Array<any>, dateToFind: string) => {
+    let middle = Math.floor((start + end) / 2);
+    if (dateList[middle] > dateToFind) {
+      end = middle - 1;
+    } else {
+      start = middle + 1;
+    }
+    return { start, end };
+  }
+
+  findFirstDateGreaterOrEqualTarget = (start: number, end: number, dateList: Array<any>, dateToFind: string) => {
+    let middle = Math.floor((start + end) / 2);
+    if (dateList[middle] < dateToFind) {
+      start = middle + 1;
+    } else {
+      end = middle - 1;
+    }
+    return { start, end };
+  }
+
   createSeriesChart(dateRange, transformations) {
     const { level, yoy, ytd, c5ma } = transformations;
     const levelValue = [];
@@ -472,31 +515,31 @@ export class HelperService {
     return this.getRanges(freq, counter, defaultSettings.range);
   }
 
-  getSeriesStartAndEnd = (dates: Array<any>, start: string, end: string, freq: string, defaultRange) => {
+  getSeriesStartAndEnd = (dates: any, start: string, end: string, freq: string, defaultRange) => {
     const defaultRanges = this.setDefaultCategoryRange(freq, dates, defaultRange);
     let { startIndex, endIndex } = defaultRanges;
     if (start) {
-      const dateFromExists = this.checkDateExists(start, dates, freq);
+      const dateFromExists = this.checkDateExists(start, dates, freq, 'start');
       if (dateFromExists > -1) {
         startIndex = dateFromExists;
-      }
-      if (start < dates[0].date) {
-        startIndex = defaultRanges.startIndex;
+      } 
+      if (dateFromExists === -1) {
+        startIndex = 0;
       }
     }
     if (end) {
-      const dateToExists = this.checkDateExists(end, dates, freq);
+      const dateToExists = this.checkDateExists(end, dates, freq, 'end');
       if (dateToExists > -1) {
         endIndex = dateToExists;
-      }
-      if (end > dates[dates.length - 1].date) {
-        endIndex = defaultRanges.endIndex;
+      } 
+      if (dateToExists === -1) {
+        endIndex = dates.length - 1;
       }
     }
     return { seriesStart: startIndex, seriesEnd: endIndex };
   }
 
-  checkDateExists = (date: string, dates: Array<any>, freq: string) => {
+  checkDateExists = (date: string, dates: Array<any>, freq: string, boundary: string) => {
     let dateToCheck = date;
     const year = date.substring(0, 4);
     if (freq === 'A') {
@@ -518,7 +561,9 @@ export class HelperService {
       }
     }
     const dateArray = dates.map(d => d.date);
-    return this.binarySearch(dateArray, dateToCheck);
+    return boundary === 'start' ? 
+      this.binarySearchStartDate(dateArray, dateToCheck) :
+      this.binarySearchEndDate(dateArray, dateToCheck);
   }
 
   getRanges(freq: string, counter: number, range: number) {

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -336,9 +336,8 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
           points.forEach((point) => {
             if (point.y !== null) {
               const pointName = point.series.userOptions.name;
-              const displayValue = /* (pointName === 'level' || pointName === 'c5ma') ? 
-                Highcharts.numberFormat(point.y, decimals, '.', ',') : */
-                Highcharts.numberFormat(point.y, 1, '.', ',');
+              const decimal = (pointName === 'level' || pointName === 'c5ma') ? seriesData.decimals : 1;
+              const displayValue = Highcharts.numberFormat(point.y, decimal, '.', ',');
               const formattedValue = displayValue === '-0.00' ? '0.00' : displayValue;
               const { name } = point.series;
               const labelName = formatLabel(name, percent, currentFreq);

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -221,6 +221,9 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
     const { start, end } = gridDisplay;
     const decimals = seriesData.decimals || 1;
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
+    if (series1.name !== 'c5ma') {
+      series1.values = series1.values.map(val => [val[0], +Highcharts.numberFormat(val[1], 1, '.', ',')])
+    }
     series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], chartStart) : series0;
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
@@ -235,7 +238,12 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
       let subtitleText = '';
       subtitleText += `${Highcharts.numberFormat(point0.y, decimals, '.', ',')} <br> (${this.indexChecked ? 'Index' : unitsLabelShort})`;
       subtitleText += s1 ?
-      `${this.formatTransformLabel(s1.name, percent, currentFreq)}<br>${Highcharts.numberFormat(point1.y, decimals, '.', ',')}<br>${dateLabel}` :
+      `${this.formatTransformLabel(s1.name, percent, currentFreq)}<br>
+        ${
+          s1.name !== 'c5ma' ? 
+          Highcharts.numberFormat(point1.y, 1, '.', ',') : 
+          Highcharts.numberFormat(point1.y, decimals, '.', ',')
+        }<br>${dateLabel}` :
         dateLabel;
       chart.setSubtitle({
         text: subtitleText,
@@ -334,7 +342,10 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
           }
           points.forEach((point) => {
             if (point.y !== null) {
-              const displayValue = Highcharts.numberFormat(point.y, decimals, '.', ',');
+              const pointName = point.series.userOptions.name;
+              const displayValue = (pointName === 'level' || pointName === 'c5ma') ? 
+                Highcharts.numberFormat(point.y, decimals, '.', ',') :
+                Highcharts.numberFormat(point.y, 1, '.', ',');
               const formattedValue = displayValue === '-0.00' ? '0.00' : displayValue;
               const { name } = point.series;
               const labelName = formatLabel(name, percent, currentFreq);
@@ -362,7 +373,7 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
           });
           return labelString;
         };
-        if (this.x >= startDate && this.x <= endDate) {
+        if (this.x as number >= startDate && this.x as number <= endDate) {
           let s = `<b>${indexed ? indexDisplayName : displayName}</b><br>`;
           // Get Quarter or Month for Q/M frequencies
           s = s + formatDate(this.x, currentFreq);

--- a/projects/tools/src/lib/highchart/highchart.component.ts
+++ b/projects/tools/src/lib/highchart/highchart.component.ts
@@ -221,9 +221,6 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
     const { start, end } = gridDisplay;
     const decimals = seriesData.decimals || 1;
     let { series0, series1, pseudoZones } = gridDisplay.chartData;
-    if (series1.name !== 'c5ma') {
-      series1.values = series1.values.map(val => [val[0], +Highcharts.numberFormat(val[1], 1, '.', ',')])
-    }
     series0 = this.indexChecked ? this.helperService.getIndexedTransformation(observations[0], chartStart) : series0;
     const startDate = Date.parse(chartStart) || Date.parse(start);
     const endDate = Date.parse(chartEnd) || Date.parse(end);
@@ -239,11 +236,7 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
       subtitleText += `${Highcharts.numberFormat(point0.y, decimals, '.', ',')} <br> (${this.indexChecked ? 'Index' : unitsLabelShort})`;
       subtitleText += s1 ?
       `${this.formatTransformLabel(s1.name, percent, currentFreq)}<br>
-        ${
-          s1.name !== 'c5ma' ? 
-          Highcharts.numberFormat(point1.y, 1, '.', ',') : 
-          Highcharts.numberFormat(point1.y, decimals, '.', ',')
-        }<br>${dateLabel}` :
+        ${Highcharts.numberFormat(point1.y, decimals, '.', ',')}<br>${dateLabel}` :
         dateLabel;
       chart.setSubtitle({
         text: subtitleText,
@@ -343,8 +336,8 @@ export class HighchartComponent implements OnInit, OnChanges, OnDestroy {
           points.forEach((point) => {
             if (point.y !== null) {
               const pointName = point.series.userOptions.name;
-              const displayValue = (pointName === 'level' || pointName === 'c5ma') ? 
-                Highcharts.numberFormat(point.y, decimals, '.', ',') :
+              const displayValue = /* (pointName === 'level' || pointName === 'c5ma') ? 
+                Highcharts.numberFormat(point.y, decimals, '.', ',') : */
                 Highcharts.numberFormat(point.y, 1, '.', ',');
               const formattedValue = displayValue === '-0.00' ? '0.00' : displayValue;
               const { name } = point.series;

--- a/projects/tools/src/lib/highstock/highstock.component.ts
+++ b/projects/tools/src/lib/highstock/highstock.component.ts
@@ -435,7 +435,8 @@ export class HighstockComponent implements OnInit, OnDestroy {
     let s = `<b>${getFreqLabel(freq.freq, x)}</b>`;
     points.forEach((point) => {
       if (!point.series.name.includes('YTD')) {
-        const displayValue = Highcharts.numberFormat(point.y, decimals, '.', ',');
+        const decimal = point.series.name.includes('YOY') ? 1 : this.seriesDetail.decimals;
+        const displayValue = Highcharts.numberFormat(point.y, decimal, '.', ',');
         const formattedValue = displayValue === '-0.00' ? '0.00' : displayValue;
         const seriesColor = `<br><span class='series-${point.colorIndex}'>\u25CF</span>`;
         const seriesNameValue =`${point.series.name}: ${formattedValue}`;

--- a/projects/tools/src/lib/landing-page/landing-page.component.html
+++ b/projects/tools/src/lib/landing-page/landing-page.component.html
@@ -84,7 +84,7 @@
 					(selectedGeoChange)="redrawSeriesGeo($event, selectedFreq, selectedFc)" class="selector">
 				</lib-geo-selector>
 				<lib-freq-selector *ngIf="portal.universe !== 'nta'" [freqs]="data.frequencies"
-					(selectedFreqChange)="redrawSeriesFreq($event, selectedGeo, selectedFc)" class="selector">
+					(selectedFreqChange)="redrawSeriesFreq($event, selectedFreq, selectedGeo, selectedFc)" class="selector">
 				</lib-freq-selector>
 				<lib-forecast-selector *ngIf="portalSettings.selectors.includes('forecast')" [forecasts]="data.forecasts"
 					(selectedFcChange)="redrawSeriesFc($event, selectedGeo, selectedFreq)" class="selector">
@@ -113,7 +113,7 @@
 						(change)="toggleSASeries($event)">Seasonally Adjusted
 				</label>
 				<lib-date-slider *ngIf="data.displayedMeasurements" class="sliders" [portalSettings]="portalSettings"
-					[dates]="data.categoryDates" [freq]="selectedFreq?.freq || data.currentFreq.freq" [routeStart]="routeStart"
+					[dates]="data.categoryDates" [previousFreq]="previousFreq" [freq]="selectedFreq?.freq || data.currentFreq.freq" [routeStart]="routeStart"
 					[routeEnd]="routeEnd" (updateRange)="changeRange($event)"></lib-date-slider>
 			</div>
 		</ng-template>

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -111,12 +111,14 @@ export class LandingPageComponent implements OnInit, OnDestroy {
 
   // Redraw series when a new measurement is selected
   redrawSeriesMeasurements(event) {
+    this.previousFreq = '';
     this.queryParams.m = event.name;
     this.updateRoute();
   }
 
   // Redraw series when a new region is selected
   redrawSeriesGeo(event, currentFreq: Frequency, currentFc: string) {
+    this.previousFreq = '';
     this.queryParams.geo = event.handle;
     this.queryParams.freq = currentFreq.freq;
     this.queryParams.fc = currentFc;
@@ -124,20 +126,6 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   }
 
   redrawSeriesFreq(event, currentFreq: Frequency, currentGeo: Geography, currentFc: string) {
-    /* if (this.queryParams.end) {
-      const year = this.queryParams.end.slice(0, 4);
-      if (currentFreq.freq === 'A' && event.freq === 'Q') {
-        this.queryParams.end = `${year}-10-01`;
-      }
-      if (currentFreq.freq === 'A' && event.freq === 'M') {
-        this.queryParams.end = `${year}-12-01`;
-      }
-      if (currentFreq.freq === 'A' && event.freq === 'S') {
-        this.queryParams.end = `${year}-07-01`;
-      }
-      console.log('CURRENT FREQ', currentFreq)
-
-    } */
     this.previousFreq = currentFreq.freq;
     this.queryParams.geo = currentGeo.handle;
     this.queryParams.freq = event.freq;
@@ -146,6 +134,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   }
 
   redrawSeriesFc(event, currentGeo: Geography, currentFreq: Frequency) {
+    this.previousFreq = '';
     this.queryParams.geo = currentGeo.handle;
     this.queryParams.freq = currentFreq.freq;
     this.queryParams.fc = event
@@ -158,16 +147,19 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   }
 
   yoyActive(e) {
+    this.previousFreq = '';
     this.queryParams.yoy = e.target.checked;
     this.updateRoute();
   }
 
   ytdActive(e) {
+    this.previousFreq = '';
     this.queryParams.ytd = e.target.checked;
     this.updateRoute();
   }
 
   c5maActive(e) {
+    this.previousFreq = '';
     this.queryParams.c5ma = e.target.checked;
     this.updateRoute();
   }

--- a/projects/tools/src/lib/landing-page/landing-page.component.ts
+++ b/projects/tools/src/lib/landing-page/landing-page.component.ts
@@ -27,6 +27,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   portalSettings;
   seriesRange;
   displayHelp: boolean = false;
+  previousFreq: string = '';
 
   // Variables for geo and freq selectors
   public categoryData;
@@ -122,7 +123,22 @@ export class LandingPageComponent implements OnInit, OnDestroy {
     this.updateRoute();
   }
 
-  redrawSeriesFreq(event, currentGeo: Geography, currentFc: string) {
+  redrawSeriesFreq(event, currentFreq: Frequency, currentGeo: Geography, currentFc: string) {
+    /* if (this.queryParams.end) {
+      const year = this.queryParams.end.slice(0, 4);
+      if (currentFreq.freq === 'A' && event.freq === 'Q') {
+        this.queryParams.end = `${year}-10-01`;
+      }
+      if (currentFreq.freq === 'A' && event.freq === 'M') {
+        this.queryParams.end = `${year}-12-01`;
+      }
+      if (currentFreq.freq === 'A' && event.freq === 'S') {
+        this.queryParams.end = `${year}-07-01`;
+      }
+      console.log('CURRENT FREQ', currentFreq)
+
+    } */
+    this.previousFreq = currentFreq.freq;
     this.queryParams.geo = currentGeo.handle;
     this.queryParams.freq = event.freq;
     this.queryParams.fc = currentFc;
@@ -161,6 +177,7 @@ export class LandingPageComponent implements OnInit, OnDestroy {
   }
 
   changeRange(e) {
+    this.previousFreq = '';
     this.routeStart = e.useDefaultRange ? null : e.startDate;
     this.routeEnd = e.endOfSample ? null : e.endDate;
     this.queryParams.start = this.routeStart;

--- a/projects/tools/src/lib/series-helper.service.ts
+++ b/projects/tools/src/lib/series-helper.service.ts
@@ -89,7 +89,6 @@ export class SeriesHelperService {
         this.seriesData.eror = true;
         this.seriesData.requestComplete = true;
       });
-      console.log('SERIES DATA', this.seriesData)
     return observableForkJoin([observableOf(this.seriesData)]);
   }
 

--- a/projects/tools/src/lib/single-series/single-series.component.html
+++ b/projects/tools/src/lib/single-series/single-series.component.html
@@ -61,7 +61,7 @@
           </label>
         </div>
         <lib-date-slider *ngIf="data.requestComplete" class="sliders" [portalSettings]="portalSettings"
-          [dates]="data.sliderDates" [freq]="data.seriesDetail.frequencyShort" [routeStart]="routeStart"
+          [dates]="data.sliderDates" [previousFreq]="previousFreq" [freq]="data.seriesDetail.frequencyShort" [routeStart]="routeStart"
           [routeEnd]="routeEnd" (updateRange)="changeRange($event)"></lib-date-slider>
       </div>
       <p *ngIf="noSelection">{{noSelection}}</p>

--- a/projects/tools/src/lib/single-series/single-series.component.ts
+++ b/projects/tools/src/lib/single-series/single-series.component.ts
@@ -38,6 +38,7 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
   queryParams: any = {};
   routeStart: string;
   routeEnd: string;
+  previousFreq: string = '';
 
   constructor(
     @Inject('environment') private environment,
@@ -91,8 +92,6 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
       }
       this.seriesData = this.seriesHelper.getSeriesData(this.seriesId, noCache, categoryId);
     });
-
-    
   }
 
   ngAfterContentChecked() {
@@ -116,6 +115,7 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
 
   // Redraw chart when selecting a new region or frequency
   goToSeries = (siblings: Array<any>, freq: string, geo: string, sa: boolean, forecast = null) => {
+    this.previousFreq = freq === this.selectedFreq.freq ? '' : this.selectedFreq.freq;
     this.seasonallyAdjusted = sa;
     this.noSelection = null;
     // Get array of siblings for selected geo and freq

--- a/projects/tools/src/lib/single-series/single-series.component.ts
+++ b/projects/tools/src/lib/single-series/single-series.component.ts
@@ -18,7 +18,7 @@ export class SingleSeriesComponent implements OnInit, OnDestroy, AfterContentChe
   newTableData;
   tableHeaders;
   summaryStats;
-  seasonallyAdjusted = false;
+  seasonallyAdjusted = true;
   chartStart;
   chartEnd;
   portalSettings;


### PR DESCRIPTION
Allows the date ranges to auto adjust when the frequency is switched to maintain the original range selected. For example, currently, if the range 2010 - 2020 is selected at the annual level, when a user switches the frequency to quarterly, the range selects 2010 Q1 to 2020 Q1. This PR would make it so that the range selected is 2010 Q1 - 2020Q4 instead.

Other included changes:
- On the single series view, when navigating from an annual series to one at a higher frequency, the default is to display the seasonally adjusted series instead of the non-seasonal
- YOY and YTD growth rates are all rounded to 1 decimal place for charts and tables
- Bug fix for the date picker for quarterly displays (only Jan, Apr, Jul, and Aug should be selectable) and semiannual (only Jan and Jul should be selectable)